### PR TITLE
[fix] (eth,trx,xlm,xrp) resolvePayport should not throw when valid and includes index

### DIFF
--- a/packages/coinlib-ethereum/src/BaseEthereumPayments.ts
+++ b/packages/coinlib-ethereum/src/BaseEthereumPayments.ts
@@ -80,19 +80,12 @@ export abstract class BaseEthereumPayments<Config extends BaseEthereumPaymentsCo
         throw new Error(`Invalid Ethereum address: ${payport}`)
       }
       return { address: payport.toLowerCase() }
-    } else if (DerivablePayport.is(payport)) {
-      throw new Error(`Invalid Ethereum address: ${payport}`)
     }
 
-    if (!this.isValidPayport(payport)) {
-      throw new Error(`Invalid Ethereum payport: ${JSON.stringify(payport)}`)
-    } else {
-      if(!this.isValidAddress(payport.address)) {
-        throw new Error(`Invalid Ethereum payport: ${JSON.stringify(payport)}`)
-      }
+    if (this.isValidPayport(payport as any)) {
+      return { ...payport, address: (payport as any).address.toLowerCase() }
     }
-
-    return { ...payport, address: payport.address.toLowerCase() }
+    throw new Error(`Invalid Ethereum payport: ${JSON.stringify(payport)}`)
   }
 
   async resolveFromTo(from: number, to: ResolveablePayport): Promise<FromTo> {

--- a/packages/coinlib-ethereum/src/EthereumPaymentsUtils.ts
+++ b/packages/coinlib-ethereum/src/EthereumPaymentsUtils.ts
@@ -141,7 +141,7 @@ export class EthereumPaymentsUtils implements PaymentsUtils {
   }
 
   // XXX Payport methods can be moved to payments-common
-  isValidPayport(payport: Payport): boolean {
+  isValidPayport(payport: Payport): payport is Payport {
     return Payport.is(payport) && !this._getPayportValidationMessage(payport)
   }
 

--- a/packages/coinlib-ethereum/test/HdEthereumPayments.test.ts
+++ b/packages/coinlib-ethereum/test/HdEthereumPayments.test.ts
@@ -102,12 +102,20 @@ describe('HdEthereumPayments', () => {
     })
 
     describe('resolvePayport', () => {
-      test('returns object address derived from the provided key', async () => {
+      test('returns payport derived from the provided index', async () => {
         expect(await hdEP.resolvePayport(1)).toStrictEqual({ address: FROM_ADDRESS.toLowerCase() })
       })
 
-      test('returns object address if provided input is string', async () => {
+      test('returns payport using input address', async () => {
         expect(await hdEP.resolvePayport(FROM_ADDRESS)).toStrictEqual({ address: FROM_ADDRESS.toLowerCase() })
+      })
+
+      test('returns payport using input payport', async () => {
+        expect(await hdEP.resolvePayport({ address: FROM_ADDRESS })).toStrictEqual({ address: FROM_ADDRESS.toLowerCase() })
+      })
+
+      test('returns payport using input payport with index', async () => {
+        expect(await hdEP.resolvePayport({ index: 1, address: FROM_ADDRESS })).toStrictEqual({ index: 1, address: FROM_ADDRESS.toLowerCase() })
       })
 
       test('thorws an error for invalid address', async () => {

--- a/packages/coinlib-ripple/src/BaseRipplePayments.ts
+++ b/packages/coinlib-ripple/src/BaseRipplePayments.ts
@@ -104,12 +104,12 @@ export abstract class BaseRipplePayments<Config extends BaseRipplePaymentsConfig
     } else if (typeof payport === 'string') {
       assertValidAddress(payport)
       return { address: payport }
-    } else if (DerivablePayport.is(payport)) {
-      throw new Error(`Invalid Ripple payport: ${JSON.stringify(payport)}`)
+    } else if (Payport.is(payport)) {
+      assertValidAddress(payport.address)
+      assertValidExtraIdOrNil(payport.extraId)
+      return payport
     }
-    assertValidAddress(payport.address)
-    assertValidExtraIdOrNil(payport.extraId)
-    return payport
+    throw new Error(`Invalid Ripple payport: ${JSON.stringify(payport)}`)
   }
 
   async resolvePayport(payport: ResolveablePayport): Promise<Payport> {

--- a/packages/coinlib-stellar/src/BaseStellarPayments.ts
+++ b/packages/coinlib-stellar/src/BaseStellarPayments.ts
@@ -97,12 +97,12 @@ export abstract class BaseStellarPayments<Config extends BaseStellarPaymentsConf
     } else if (typeof payport === 'string') {
       assertValidAddress(payport)
       return { address: payport }
-    } else if (DerivablePayport.is(payport)) {
-      throw new Error(`Invalid Stellar payport: ${JSON.stringify(payport)}`)
+    } else if (Payport.is(payport)) {
+      assertValidAddress(payport.address)
+      assertValidExtraIdOrNil(payport.extraId)
+      return payport
     }
-    assertValidAddress(payport.address)
-    assertValidExtraIdOrNil(payport.extraId)
-    return payport
+    throw new Error(`Invalid Stellar payport: ${JSON.stringify(payport)}`)
   }
 
   async resolvePayport(payport: ResolveablePayport): Promise<Payport> {

--- a/packages/coinlib-tron/src/BaseTronPayments.ts
+++ b/packages/coinlib-tron/src/BaseTronPayments.ts
@@ -284,12 +284,10 @@ export abstract class BaseTronPayments<Config extends BaseTronPaymentsConfig> ex
         throw new Error(`Invalid TRON address: ${payport}`)
       }
       return { address: payport }
-    } else if (DerivablePayport.is(payport)) {
-      throw new Error(`Invalid TRON payport: ${JSON.stringify(payport)}`)
-    } else if (!this.isValidPayport(payport)) {
-      throw new Error(`Invalid TRON payport: ${JSON.stringify(payport)}`)
+    } else if (this.isValidPayport(payport as any)) {
+      return payport as Payport
     }
-    return payport
+    throw new Error(`Invalid TRON payport: ${JSON.stringify(payport)}`)
   }
 
   async resolveFromTo(from: number, to: ResolveablePayport): Promise<FromTo> {

--- a/packages/coinlib-tron/src/TronPaymentsUtils.ts
+++ b/packages/coinlib-tron/src/TronPaymentsUtils.ts
@@ -80,7 +80,7 @@ export class TronPaymentsUtils implements PaymentsUtils {
     return address
   }
 
-  private async _getPayportValidationMessage(payport: Payport): Promise<string | undefined> {
+  private _getPayportValidationMessage(payport: Payport): string | undefined {
     const { address, extraId } = payport
     if (!isValidAddress(address)) {
       return 'Invalid payport address'
@@ -90,7 +90,7 @@ export class TronPaymentsUtils implements PaymentsUtils {
     }
   }
 
-  async getPayportValidationMessage(payport: Payport): Promise<string | undefined> {
+  getPayportValidationMessage(payport: Payport): string | undefined {
     try {
       payport = assertType(Payport, payport, 'payport')
     } catch (e) {
@@ -99,16 +99,16 @@ export class TronPaymentsUtils implements PaymentsUtils {
     return this._getPayportValidationMessage(payport)
   }
 
-  async validatePayport(payport: Payport): Promise<void> {
+  validatePayport(payport: Payport): void {
     payport = assertType(Payport, payport, 'payport')
-    const message = await this._getPayportValidationMessage(payport)
+    const message = this._getPayportValidationMessage(payport)
     if (message) {
       throw new Error(message)
     }
   }
 
-  async isValidPayport(payport: Payport): Promise<boolean> {
-    return Payport.is(payport) && !(await this._getPayportValidationMessage(payport))
+  isValidPayport(payport: Payport): payport is Payport {
+    return Payport.is(payport) && !(this._getPayportValidationMessage(payport))
   }
 
   toMainDenomination(amount: string | number): string {

--- a/packages/coinlib-tron/test/HdTronPayments.test.ts
+++ b/packages/coinlib-tron/test/HdTronPayments.test.ts
@@ -85,6 +85,10 @@ function runHardcodedPublicKeyTests(tp: HdTronPayments, config: HdTronPaymentsCo
     const payport = { address: ADDRESSES[1] }
     expect(await tp.resolvePayport(payport)).toEqual(payport)
   })
+  it('resolvePayport resolves for payport with index', async () => {
+    const payport = { index: 1, address: ADDRESSES[1] }
+    expect(await tp.resolvePayport(payport)).toEqual(payport)
+  })
   it('resolvePayport throws for invalid address', async () => {
     await expect(tp.resolvePayport('invalid')).rejects.toThrow()
   })


### PR DESCRIPTION
resolvePayport was incorrectly throwing an error when a valid payport was provided that also included an index (and other misc fields)