### PR TITLE
Fix erc20 tx info timestamp

### DIFF
--- a/packages/coinlib-ethereum/src/erc20/BaseErc20Payments.ts
+++ b/packages/coinlib-ethereum/src/erc20/BaseErc20Payments.ts
@@ -264,7 +264,7 @@ export abstract class BaseErc20Payments <Config extends BaseErc20PaymentsConfig>
       if (confirmations > minConfirmations) {
         isConfirmed = true
         txBlock = await this._retryDced(() => this.eth.getBlock(tx.blockNumber!))
-        confirmationTimestamp = new Date(txBlock.timestamp)
+        confirmationTimestamp = new Date(Number(txBlock.timestamp) * 1000)
       }
     }
 


### PR DESCRIPTION
# Description of the change

eth block timestamps are measured in seconds but nodejs Date expects ms