### PR TITLE
[fix] (erc20) Return details of token transfer when instantiating token utils

### DIFF
--- a/packages/coinlib-ethereum/src/EthereumPaymentsUtils.ts
+++ b/packages/coinlib-ethereum/src/EthereumPaymentsUtils.ts
@@ -21,10 +21,14 @@ import {
   isNumber
 } from '@faast/ts-common'
 import BigNumber from 'bignumber.js'
-import { Transaction, TransactionReceipt } from 'web3-core'
+import type { TransactionReceipt, Transaction } from 'web3-core'
+import Contract from 'web3-eth-contract'
+import InputDataDecoder from 'ethereum-input-data-decoder'
 
+import { deriveAddress } from './erc20/deriveAddress'
+import * as SIGNATURE from './erc20/constants'
 import {
-  PACKAGE_NAME, ETH_DECIMAL_PLACES, ETH_NAME, ETH_SYMBOL, DEFAULT_ADDRESS_FORMAT, MIN_SWEEPABLE_WEI, MIN_CONFIRMATIONS,
+  PACKAGE_NAME, ETH_DECIMAL_PLACES, ETH_NAME, ETH_SYMBOL, DEFAULT_ADDRESS_FORMAT, MIN_SWEEPABLE_WEI, MIN_CONFIRMATIONS, TOKEN_METHODS_ABI, TOKEN_WALLET_ABI_LEGACY, TOKEN_WALLET_ABI,
 } from './constants'
 import { EthereumAddressFormat, EthereumAddressFormatT, EthereumPaymentsUtilsConfig, EthereumTransactionInfo } from './types'
 import { isValidXkey } from './bip44'
@@ -38,6 +42,7 @@ export class EthereumPaymentsUtils implements PaymentsUtils {
   readonly coinSymbol: string
   readonly coinName: string
   readonly coinDecimals: number
+  readonly tokenAddress?: string
 
   logger: Logger
   server: string | null
@@ -51,6 +56,7 @@ export class EthereumPaymentsUtils implements PaymentsUtils {
     this.coinName = config.name ?? ETH_NAME
     this.coinSymbol = config.symbol ?? ETH_SYMBOL
     this.coinDecimals = config.decimals ?? ETH_DECIMAL_PLACES
+    this.tokenAddress = config.tokenAddress?.toLowerCase()
     this.server = config.fullNode || null
 
     let provider: any
@@ -220,7 +226,32 @@ export class EthereumPaymentsUtils implements PaymentsUtils {
     return this.toBaseDenominationBigNumberEth(balanceEth).gt(MIN_SWEEPABLE_WEI)
   }
 
+  protected newContract(...args: ConstructorParameters<typeof Contract>) {
+    const contract = new Contract(...args)
+    contract.setProvider(this.eth.currentProvider)
+    return contract
+  }
+
+  async getAddressBalanceERC20(address: string, tokenAddress: string): Promise<BalanceResult> {
+    const contract = this.newContract(TOKEN_METHODS_ABI, this.tokenAddress)
+    const balance = await contract.methods.balanceOf(address).call({})
+
+    const sweepable = this.toMainDenominationBigNumber(balance).gt(0)
+
+    return {
+      confirmedBalance: this.toMainDenomination(balance),
+      unconfirmedBalance: '0',
+      spendableBalance: this.toMainDenomination(balance),
+      sweepable,
+      requiresActivation: false,
+    }
+  }
+
   async getAddressBalance(address: string): Promise<BalanceResult> {
+    if (this.tokenAddress) {
+      return this.getAddressBalanceERC20(address, this.tokenAddress)
+    }
+
     const balance = await this._retryDced(() => this.eth.getBalance(address))
     const confirmedBalance = this.toMainDenomination(balance).toString()
     const sweepable = this.isAddressBalanceSweepable(confirmedBalance)
@@ -242,7 +273,213 @@ export class EthereumPaymentsUtils implements PaymentsUtils {
     return []
   }
 
+  private getErc20TransferLogAmount(txReceipt: TransactionReceipt): string {
+    const transferLog = txReceipt.logs.find((log) => log.topics[0] === SIGNATURE.LOG_TOPIC0_ERC20_SWEEP)
+    if (!transferLog) {
+      this.logger.warn(`Transaction ${txReceipt.transactionHash} was an ERC20 sweep but cannot find log for Transfer event`)
+      return '0'
+    }
+    return this.toMainDenomination(transferLog.data)
+  }
+
+  async getTransactionInfoERC20(txid: string): Promise<EthereumTransactionInfo> {
+    const minConfirmations = MIN_CONFIRMATIONS
+    const tx: Transaction | null = await this._retryDced(() => this.eth.getTransaction(txid))
+
+    if (!tx) {
+      throw new Error(`Transaction ${txid} not found`)
+    }
+
+    if (!tx.input) {
+      throw new Error(`Transaction ${txid} has no input data so it can't be an ERC20 tx`)
+    }
+
+    const currentBlockNumber = await this.getCurrentBlockNumber()
+    let txReceipt: TransactionReceipt | null = await this._retryDced(() => this.eth.getTransactionReceipt(txid))
+
+    let txBlock: any = null
+    let isConfirmed = false
+    let confirmationTimestamp: Date | null = null
+    let confirmations = 0
+    if (tx.blockNumber) {
+      confirmations = currentBlockNumber - tx.blockNumber
+      if (confirmations > minConfirmations) {
+        isConfirmed = true
+        txBlock = await this._retryDced(() => this.eth.getBlock(tx.blockNumber!))
+        confirmationTimestamp = new Date(Number(txBlock.timestamp) * 1000)
+      }
+    }
+
+    let status: TransactionStatus = TransactionStatus.Pending
+    let isExecuted = false
+    if (isConfirmed) {
+      status = TransactionStatus.Confirmed
+      isExecuted = true
+      // No trust to types description of web3
+      if (txReceipt && (txReceipt?.status === false || txReceipt.status.toString() === 'false')) {
+        status = TransactionStatus.Failed
+        isExecuted = false
+      }
+    }
+
+    let fromAddress = tx.from.toLowerCase()
+    let toAddress = ''
+    let amount = ''
+
+    if (tx.input.startsWith(SIGNATURE.ERC20_TRANSFER)) {
+      if((tx.to || '').toLowerCase() !== this.tokenAddress!.toLowerCase()) {
+        throw new Error(`Transaction ${txid} was sent to different contract: ${tx.to}, Expected: ${this.tokenAddress}`)
+      }
+
+      const tokenDecoder = new InputDataDecoder(TOKEN_METHODS_ABI)
+      const txData = tokenDecoder.decodeData(tx.input)
+      toAddress = this.web3.utils.toChecksumAddress(txData.inputs[0]).toLowerCase()
+      amount = this.toMainDenomination(txData.inputs[1].toString())
+      if (txReceipt) {
+        const actualAmount = this.getErc20TransferLogAmount(txReceipt)
+        if (isExecuted && amount !== actualAmount) {
+          this.logger.warn(
+            `Transcation ${txid} tried to transfer ${amount} but only ${actualAmount} was actually transferred`
+          )
+        }
+      }
+    } else if (tx.input.startsWith(SIGNATURE.ERC20_SWEEP_CONTRACT_DEPLOY)
+      || tx.input.startsWith(SIGNATURE.ERC20_SWEEP_CONTRACT_DEPLOY_LEGACY)) {
+      amount = '0'
+    } else if (tx.input.startsWith(SIGNATURE.ERC20_PROXY)) {
+      amount = '0'
+    } else if (tx.input.startsWith(SIGNATURE.ERC20_SWEEP)) {
+      const tokenDecoder = new InputDataDecoder(TOKEN_WALLET_ABI)
+      const txData = tokenDecoder.decodeData(tx.input)
+
+      if (txData.inputs.length !== 4) {
+        throw new Error(`Transaction ${txid} has not recognized number of inputs ${txData.inputs.length}`)
+      }
+      // For ERC20 sweeps:
+      // tx.from is the contract address
+      // inputs[0] is salt
+      // inputs[1] is the ERC20 contract address (this.tokenAddress)
+      // inputs[2] is the recipient of the funds (toAddress)
+      // inputs[3] is the amount
+      const sweepContractAddress = tx.to
+      if (!sweepContractAddress) {
+        throw new Error(`Transaction ${txid} should have a to address destination`)
+      }
+
+      const addr = deriveAddress(
+        sweepContractAddress,
+        `0x${txData.inputs[0].toString('hex')}`,
+        true
+      )
+
+      fromAddress = this.web3.utils.toChecksumAddress(addr).toLowerCase()
+      toAddress = this.web3.utils.toChecksumAddress(txData.inputs[2]).toLowerCase()
+      if (txReceipt) {
+        amount = this.getErc20TransferLogAmount(txReceipt)
+      } else {
+        amount = this.toMainDenomination(txData.inputs[3].toString())
+      }
+    } else if (tx.input.startsWith(SIGNATURE.ERC20_SWEEP_LEGACY)) {
+      const tokenDecoder = new InputDataDecoder(TOKEN_WALLET_ABI_LEGACY)
+      const txData = tokenDecoder.decodeData(tx.input)
+
+      if (txData.inputs.length !== 2) {
+        throw new Error(`Transaction ${txid} has not recognized number of inputs ${txData.inputs.length}`)
+      }
+      // For ERC20 legacy sweeps:
+      // tx.to is the sweep contract address and source of funds (fromAddress)
+      // tx.from is the contract owner address
+      // inputs[0] is the ERC20 contract address (this.tokenAddress)
+      // inputs[1] is the recipient of the funds (toAddress)
+      const sweepContractAddress = tx.to
+      if (!sweepContractAddress) {
+        throw new Error(`Transaction ${txid} should have a to address destination`)
+      }
+      fromAddress = this.web3.utils.toChecksumAddress(sweepContractAddress).toLowerCase()
+      toAddress = this.web3.utils.toChecksumAddress(txData.inputs[1]).toLowerCase()
+
+      if (txReceipt) {
+        amount = this.getErc20TransferLogAmount(txReceipt)
+      }
+    } else {
+      throw new Error(`Transaction ${txid} is not ERC20 transaction neither swap`)
+    }
+
+    // NOTE: for the sake of consistent schema return
+    if (!txReceipt) {
+      txReceipt = {
+        transactionHash: tx.hash,
+        from: tx.from || '',
+        to: toAddress,
+        status: true,
+        blockNumber: 0,
+        cumulativeGasUsed: 0,
+        gasUsed: 0,
+        transactionIndex: 0,
+        blockHash: '',
+        logs: [],
+        logsBloom: ''
+      }
+
+      return {
+        id: txid,
+        amount,
+        toAddress,
+        fromAddress: tx.from,
+        toExtraId: null,
+        fromIndex: null,
+        toIndex: null,
+        fee: this.toMainDenominationEth((new BigNumber(tx.gasPrice)).multipliedBy(tx.gas)),
+        sequenceNumber: tx.nonce,
+        weight: tx.gas,
+        isExecuted: false,
+        isConfirmed: false,
+        confirmations: 0,
+        confirmationId: null,
+        confirmationTimestamp: null,
+        currentBlockNumber: currentBlockNumber,
+        status: TransactionStatus.Pending,
+        data: {
+          ...tx,
+          ...txReceipt,
+          currentBlock: currentBlockNumber
+        },
+      }
+    }
+
+    return {
+      id: txid,
+      amount,
+      toAddress,
+      fromAddress,
+      toExtraId: null,
+      fromIndex: null,
+      toIndex: null,
+      fee: this.toMainDenominationEth((new BigNumber(tx.gasPrice)).multipliedBy(txReceipt.gasUsed)),
+      sequenceNumber: tx.nonce,
+      weight: txReceipt.gasUsed,
+      // XXX if tx was confirmed but not accepted by network isExecuted must be false
+      isExecuted,
+      isConfirmed,
+      confirmations,
+      confirmationId: tx.blockHash,
+      confirmationTimestamp,
+      status,
+      currentBlockNumber: currentBlockNumber,
+      data: {
+        ...tx,
+        ...txReceipt,
+        currentBlock: currentBlockNumber
+      },
+    }
+  }
+
   async getTransactionInfo(txid: string): Promise<EthereumTransactionInfo> {
+    // If a tokenAddress has been defined, this is an ERC20 utils so use different decoding logic
+    if (this.tokenAddress) {
+      return this.getTransactionInfoERC20(txid)
+    }
+
     // XXX it is suggested to keep 12 confirmations
     // https://ethereum.stackexchange.com/questions/319/what-number-of-confirmations-is-considered-secure-in-ethereum
     const minConfirmations = MIN_CONFIRMATIONS

--- a/packages/coinlib-ethereum/src/erc20/BaseErc20Payments.ts
+++ b/packages/coinlib-ethereum/src/erc20/BaseErc20Payments.ts
@@ -1,10 +1,4 @@
-import InputDataDecoder from 'ethereum-input-data-decoder'
 import { BigNumber } from 'bignumber.js'
-import type { TransactionReceipt, Transaction } from 'web3-core'
-import Contract from 'web3-eth-contract'
-
-import { deriveAddress } from './deriveAddress'
-
 import {
   BalanceResult,
   TransactionStatus,
@@ -13,6 +7,7 @@ import {
   PaymentsError,
   PaymentsErrorCode,
 } from '@bitaccess/coinlib-common'
+import { Numeric } from '@faast/ts-common'
 
 import {
   BaseErc20PaymentsConfig,
@@ -28,16 +23,17 @@ import {
   DEPOSIT_KEY_INDEX,
 } from '../constants'
 import { BaseEthereumPayments } from '../BaseEthereumPayments'
-import * as SIGNATURE from './constants'
-import { Numeric } from '@faast/ts-common'
 
 export abstract class BaseErc20Payments <Config extends BaseErc20PaymentsConfig> extends BaseEthereumPayments<Config> {
-  public tokenAddress: string
   public depositKeyIndex: number
   public masterAddress: string
+  public tokenAddress: string
 
   constructor(config: Config) {
     super(config)
+    if (!config.tokenAddress) {
+      throw new Error(`config.tokenAddress is required to instantiate ERC20 payments`)
+    }
     this.tokenAddress = config.tokenAddress.toLowerCase()
     this.masterAddress = (config.masterAddress || '').toLowerCase()
 
@@ -46,28 +42,6 @@ export abstract class BaseErc20Payments <Config extends BaseErc20PaymentsConfig>
 
   abstract getAddressSalt(index: number): string
   abstract getPayport(index: number): Promise<Payport>
-
-  private newContract(...args: ConstructorParameters<typeof Contract>) {
-    const contract = new Contract(...args)
-    contract.setProvider(this.eth.currentProvider)
-    return contract
-  }
-
-  async getBalance(resolveablePayport: ResolveablePayport): Promise<BalanceResult> {
-    const payport = await this.resolvePayport(resolveablePayport)
-    const contract = this.newContract(TOKEN_METHODS_ABI, this.tokenAddress)
-    const balance = await contract.methods.balanceOf(payport.address).call({})
-
-    const sweepable = await this.isSweepableBalance(this.toMainDenomination(balance))
-
-    return {
-      confirmedBalance: this.toMainDenomination(balance),
-      unconfirmedBalance: '0',
-      spendableBalance: this.toMainDenomination(balance),
-      sweepable,
-      requiresActivation: false,
-    }
-  }
 
   async isSweepableBalance(balance: Numeric): Promise<boolean> {
     // Any ERC20 balance greater than 0 is sweepable
@@ -228,207 +202,6 @@ export abstract class BaseErc20Payments <Config extends BaseErc20PaymentsConfig>
       sequenceNumber: nonce.toString(),
       weight: amountOfGas,
       data: transactionObject,
-    }
-  }
-
-  private getErc20TransferLogAmount(txReceipt: TransactionReceipt): string {
-    const transferLog = txReceipt.logs.find((log) => log.topics[0] === SIGNATURE.LOG_TOPIC0_ERC20_SWEEP)
-    if (!transferLog) {
-      this.logger.warn(`Transaction ${txReceipt.transactionHash} was an ERC20 sweep but cannot find log for Transfer event`)
-      return '0'
-    }
-    return this.toMainDenomination(transferLog.data)
-  }
-
-  async getTransactionInfo(txid: string): Promise<EthereumTransactionInfo> {
-    const minConfirmations = MIN_CONFIRMATIONS
-    const tx: Transaction | null = await this._retryDced(() => this.eth.getTransaction(txid))
-
-    if (!tx) {
-      throw new Error(`Transaction ${txid} not found`)
-    }
-
-    if (!tx.input) {
-      throw new Error(`Transaction ${txid} has no input data so it can't be an ERC20 tx`)
-    }
-
-    const currentBlockNumber = await this.getCurrentBlockNumber()
-    let txReceipt: TransactionReceipt | null = await this._retryDced(() => this.eth.getTransactionReceipt(txid))
-
-    let txBlock: any = null
-    let isConfirmed = false
-    let confirmationTimestamp: Date | null = null
-    let confirmations = 0
-    if (tx.blockNumber) {
-      confirmations = currentBlockNumber - tx.blockNumber
-      if (confirmations > minConfirmations) {
-        isConfirmed = true
-        txBlock = await this._retryDced(() => this.eth.getBlock(tx.blockNumber!))
-        confirmationTimestamp = new Date(Number(txBlock.timestamp) * 1000)
-      }
-    }
-
-    let status: TransactionStatus = TransactionStatus.Pending
-    let isExecuted = false
-    if (isConfirmed) {
-      status = TransactionStatus.Confirmed
-      isExecuted = true
-      // No trust to types description of web3
-      if (txReceipt && (txReceipt?.status === false || txReceipt.status.toString() === 'false')) {
-        status = TransactionStatus.Failed
-        isExecuted = false
-      }
-    }
-
-    let fromAddress = tx.from.toLowerCase()
-    let toAddress = ''
-    let amount = ''
-
-    if (tx.input.startsWith(SIGNATURE.ERC20_TRANSFER)) {
-      if((tx.to || '').toLowerCase() !== this.tokenAddress.toLowerCase()) {
-        throw new Error(`Transaction ${txid} was sent to different contract: ${tx.to}, Expected: ${this.tokenAddress}`)
-      }
-
-      const tokenDecoder = new InputDataDecoder(TOKEN_METHODS_ABI)
-      const txData = tokenDecoder.decodeData(tx.input)
-      toAddress = this.web3.utils.toChecksumAddress(txData.inputs[0]).toLowerCase()
-      amount = this.toMainDenomination(txData.inputs[1].toString())
-      if (txReceipt) {
-        const actualAmount = this.getErc20TransferLogAmount(txReceipt)
-        if (isExecuted && amount !== actualAmount) {
-          this.logger.warn(
-            `Transcation ${txid} tried to transfer ${amount} but only ${actualAmount} was actually transferred`
-          )
-        }
-      }
-    } else if (tx.input.startsWith(SIGNATURE.ERC20_SWEEP_CONTRACT_DEPLOY)
-      || tx.input.startsWith(SIGNATURE.ERC20_SWEEP_CONTRACT_DEPLOY_LEGACY)) {
-      amount = '0'
-    } else if (tx.input.startsWith(SIGNATURE.ERC20_PROXY)) {
-      amount = '0'
-    } else if (tx.input.startsWith(SIGNATURE.ERC20_SWEEP)) {
-      const tokenDecoder = new InputDataDecoder(TOKEN_WALLET_ABI)
-      const txData = tokenDecoder.decodeData(tx.input)
-
-      if (txData.inputs.length !== 4) {
-        throw new Error(`Transaction ${txid} has not recognized number of inputs ${txData.inputs.length}`)
-      }
-      // For ERC20 sweeps:
-      // tx.from is the contract address
-      // inputs[0] is salt
-      // inputs[1] is the ERC20 contract address (this.tokenAddress)
-      // inputs[2] is the recipient of the funds (toAddress)
-      // inputs[3] is the amount
-      const sweepContractAddress = tx.to
-      if (!sweepContractAddress) {
-        throw new Error(`Transaction ${txid} should have a to address destination`)
-      }
-
-      const addr = deriveAddress(
-        this.masterAddress,
-        `0x${txData.inputs[0].toString('hex')}`,
-        true
-      )
-
-      fromAddress = this.web3.utils.toChecksumAddress(addr).toLowerCase()
-      toAddress = this.web3.utils.toChecksumAddress(txData.inputs[2]).toLowerCase()
-      if (txReceipt) {
-        amount = this.getErc20TransferLogAmount(txReceipt)
-      } else {
-        amount = this.toMainDenomination(txData.inputs[3].toString())
-      }
-    } else if (tx.input.startsWith(SIGNATURE.ERC20_SWEEP_LEGACY)) {
-      const tokenDecoder = new InputDataDecoder(TOKEN_WALLET_ABI_LEGACY)
-      const txData = tokenDecoder.decodeData(tx.input)
-
-      if (txData.inputs.length !== 2) {
-        throw new Error(`Transaction ${txid} has not recognized number of inputs ${txData.inputs.length}`)
-      }
-      // For ERC20 legacy sweeps:
-      // tx.to is the sweep contract address and source of funds (fromAddress)
-      // tx.from is the contract owner address
-      // inputs[0] is the ERC20 contract address (this.tokenAddress)
-      // inputs[1] is the recipient of the funds (toAddress)
-      const sweepContractAddress = tx.to
-      if (!sweepContractAddress) {
-        throw new Error(`Transaction ${txid} should have a to address destination`)
-      }
-      fromAddress = this.web3.utils.toChecksumAddress(sweepContractAddress).toLowerCase()
-      toAddress = this.web3.utils.toChecksumAddress(txData.inputs[1]).toLowerCase()
-
-      if (txReceipt) {
-        amount = this.getErc20TransferLogAmount(txReceipt)
-      }
-    } else {
-      throw new Error(`Transaction ${txid} is not ERC20 transaction neither swap`)
-    }
-
-    // NOTE: for the sake of consistent schema return
-    if (!txReceipt) {
-      txReceipt = {
-        transactionHash: tx.hash,
-        from: tx.from || '',
-        to: toAddress,
-        status: true,
-        blockNumber: 0,
-        cumulativeGasUsed: 0,
-        gasUsed: 0,
-        transactionIndex: 0,
-        blockHash: '',
-        logs: [],
-        logsBloom: ''
-      }
-
-      return {
-        id: txid,
-        amount,
-        toAddress,
-        fromAddress: tx.from,
-        toExtraId: null,
-        fromIndex: null,
-        toIndex: null,
-        fee: this.toMainDenominationEth((new BigNumber(tx.gasPrice)).multipliedBy(tx.gas)),
-        sequenceNumber: tx.nonce,
-        weight: tx.gas,
-        isExecuted: false,
-        isConfirmed: false,
-        confirmations: 0,
-        confirmationId: null,
-        confirmationTimestamp: null,
-        currentBlockNumber: currentBlockNumber,
-        status: TransactionStatus.Pending,
-        data: {
-          ...tx,
-          ...txReceipt,
-          currentBlock: currentBlockNumber
-        },
-      }
-    }
-
-    return {
-      id: txid,
-      amount,
-      toAddress,
-      fromAddress,
-      toExtraId: null,
-      fromIndex: null,
-      toIndex: null,
-      fee: this.toMainDenominationEth((new BigNumber(tx.gasPrice)).multipliedBy(txReceipt.gasUsed)),
-      sequenceNumber: tx.nonce,
-      weight: txReceipt.gasUsed,
-      // XXX if tx was confirmed but not accepted by network isExecuted must be false
-      isExecuted,
-      isConfirmed,
-      confirmations,
-      confirmationId: tx.blockHash,
-      confirmationTimestamp,
-      status,
-      currentBlockNumber: currentBlockNumber,
-      data: {
-        ...tx,
-        ...txReceipt,
-        currentBlock: currentBlockNumber
-      },
     }
   }
 

--- a/packages/coinlib-ethereum/src/types.ts
+++ b/packages/coinlib-ethereum/src/types.ts
@@ -67,6 +67,7 @@ export const EthereumPaymentsUtilsConfig = extendCodec(
     decimals: t.number,
     providerOptions: t.any,
     web3: t.any,
+    tokenAddress: t.string,
   },
   'EthereumPaymentsUtilsConfig'
 )


### PR DESCRIPTION
By default if you instantiate a new utils instance for a token the implementation only understands ether balances and ether transaction infos. However in order to be more correct, it should understand how to parse token transfers and retrieve token balances so that when utils is instantiated with ERC20 params it returns the correct results.