### PR TITLE
Return array of balance activities

### DIFF
--- a/packages/coinlib-bitcoin/src/bitcoinish/BitcoinishBalanceMonitor.ts
+++ b/packages/coinlib-bitcoin/src/bitcoinish/BitcoinishBalanceMonitor.ts
@@ -207,13 +207,13 @@ export abstract class BitcoinishBalanceMonitor extends BlockbookConnected implem
     return address ? this.utils.standardizeAddress(address) : null
   }
 
-  async txToBalanceActivity(address: string, tx: NormalizedTxBitcoin): Promise<BalanceActivity | null> {
+  async txToBalanceActivity(address: string, tx: NormalizedTxBitcoin): Promise<BalanceActivity[]> {
     const externalId = tx.txid
     const confirmationNumber = tx.blockHeight
     const standardizedAddress = this.utils.standardizeAddress(address)
     if (standardizedAddress === null) {
       this.logger.warn(`Cannot standardize ${this.coinName} address, likely invalid: ${address}`)
-      return null
+      return []
     }
 
     let netSatoshis = new BigNumber(0) // balance increase (positive), or decreased (negative)
@@ -263,10 +263,10 @@ export abstract class BitcoinishBalanceMonitor extends BlockbookConnected implem
         `${this.coinName} transaction ${externalId} does not affect balance of ${standardizedAddress}`,
         tx,
       )
-      return null
+      return []
     }
 
-    return {
+    return [{
       type: netSatoshis.gt(0) ? 'in' : 'out',
       networkType: this.networkType,
       networkSymbol: this.coinSymbol,
@@ -284,7 +284,7 @@ export abstract class BitcoinishBalanceMonitor extends BlockbookConnected implem
       timestamp: new Date(tx.blockTime * 1000),
       utxosSpent,
       utxosCreated,
-    }
+    }]
   }
 
 }

--- a/packages/coinlib-common/src/BalanceMonitor.ts
+++ b/packages/coinlib-common/src/BalanceMonitor.ts
@@ -74,7 +74,7 @@ export interface BalanceMonitor {
    * @param address The address the balance activity should apply to
    * @param tx The raw transaction object returned by the network
    */
-  txToBalanceActivity(address: string, tx: object): Promise<BalanceActivity | BalanceActivity[] | null>
+  txToBalanceActivity(address: string, tx: object): Promise<BalanceActivity[]>
 
   /**
    * Watch for confirmed blocks

--- a/packages/coinlib-common/src/types.ts
+++ b/packages/coinlib-common/src/types.ts
@@ -396,7 +396,7 @@ export const GetBalanceActivityOptions = t.partial(
 )
 export type GetBalanceActivityOptions = t.TypeOf<typeof GetBalanceActivityOptions>
 
-export type BalanceActivityCallback = (ba: BalanceActivity, rawTx?: any) => Promise<void> | void
+export type BalanceActivityCallback = (ba: BalanceActivity[], rawTx?: any) => Promise<void> | void
 export const BalanceActivityCallback = functionT<BalanceActivityCallback>('BalanceActivityCallback')
 
 export type NewBlockCallback = (b: { height: number, hash: string }) => Promise<void> | void


### PR DESCRIPTION
# Description of the change

- change the `txToBalanceActivity` method on the base`BalanceMonitor` interface to only return an `BalanceActivity[]`, so this change further cascaded down into the BalanceMonitor implementation for all our supported coins.
- tweak the `txToBalanceActivity` method on the `EthereumBalanceMonitor` to
i. reflect a net change in the address i.e includes fees in the balance activity amount
ii. use the correct sign for the amount, `out` type activies should be `negative`, `in` should be positive.  

the other changes are auto-formatting changes. 