### PR TITLE
GG-74 replace all @faast/ts-common to @bitaccess/ts-common in coinlib-common

### DIFF
--- a/packages/coinlib-common/src/BasePayments.ts
+++ b/packages/coinlib-common/src/BasePayments.ts
@@ -1,4 +1,4 @@
-import { Numeric } from '@faast/ts-common'
+import { Numeric } from '@bitaccess/ts-common'
 import {
   BalanceResult,
   BaseUnsignedTransaction,

--- a/packages/coinlib-common/src/PaymentsUtils.ts
+++ b/packages/coinlib-common/src/PaymentsUtils.ts
@@ -1,4 +1,4 @@
-import { Numeric } from '@faast/ts-common'
+import { Numeric } from '@bitaccess/ts-common'
 import {
   Payport, MaybePromise, AutoFeeLevels, FeeRate, NetworkType,
   UtxoInfo, BalanceResult, BaseTransactionInfo, BlockInfo, GetFeeRecommendationOptions, GetTransactionInfoOptions

--- a/packages/coinlib-common/src/types.ts
+++ b/packages/coinlib-common/src/types.ts
@@ -9,7 +9,7 @@ import {
   functionT,
   Numeric,
   optional,
-} from '@faast/ts-common'
+} from '@bitaccess/ts-common'
 
 export type MaybePromise<T> = Promise<T> | T
 

--- a/packages/coinlib-common/src/utils.ts
+++ b/packages/coinlib-common/src/utils.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from './SharedDependencies'
-import { Numeric } from '@faast/ts-common'
+import { Numeric } from '@bitaccess/ts-common'
 
 export function isMatchingError(e: Error, partialMessages: string[]) {
   const messageLower = e.toString().toLowerCase()


### PR DESCRIPTION
# Description of the change

Some bignumber related types in coinlib-common was still from @faast/ts-common, which caused type inconsistency.
This pr removed all @faast/ts-common uses from coinlib-common.
