### PR TITLE
fix: relative path in build script

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -4,4 +4,4 @@
 # Usage: build.sh <package_dir> [...args]
 
 cd "$1"
-tsc -p "$1/tsconfig.build.json"
+tsc -p ./tsconfig.build.json

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "packages/coin-payments/dist/index.cjs.js",
   "module": "packages/coin-payments/dist/index.es.js",
   "browser": "packages/coin-payments/dist/index.umd.js",
-  "types": "packages/coin-payments/dist/lib/index.d.ts",
-  "esnext": "packages/coin-payments/dist/lib/index.js",
+  "types": "packages/coin-payments/dist/index.d.ts",
+  "esnext": "packages/coin-payments/dist/index.js",
   "repository": "https://github.com/bitaccess/coin-payments/tree/master/packages/coin-payments",
   "keywords": [
     "coin",

--- a/packages/coinlib-bitcoin-cash/package.json
+++ b/packages/coinlib-bitcoin-cash/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "browser": "dist/index.umd.js",
-  "types": "dist/lib/index.d.ts",
-  "esnext": "dist/lib/index.js",
+  "types": "dist/index.d.ts",
+  "esnext": "dist/index.js",
   "repository": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib-bitcoin-cash",
   "homepage": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib-bitcoin-cash#readme",
   "bugs": {

--- a/packages/coinlib-bitcoin-cash/tsconfig.build.json
+++ b/packages/coinlib-bitcoin-cash/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.build.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib",
+    "outDir": "dist",
   },
   "include": ["src"]
 }

--- a/packages/coinlib-bitcoin-cash/tsconfig.json
+++ b/packages/coinlib-bitcoin-cash/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib"
+    "outDir": "dist"
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/coinlib-bitcoin/package.json
+++ b/packages/coinlib-bitcoin/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "browser": "dist/index.umd.js",
-  "types": "dist/lib/index.d.ts",
-  "esnext": "dist/lib/index.js",
+  "types": "dist/index.d.ts",
+  "esnext": "dist/index.js",
   "repository": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib-bitcoin",
   "homepage": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib-bitcoin#readme",
   "bugs": {

--- a/packages/coinlib-bitcoin/tsconfig.build.json
+++ b/packages/coinlib-bitcoin/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.build.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib",
+    "outDir": "dist",
   },
   "include": ["src"]
 }

--- a/packages/coinlib-bitcoin/tsconfig.json
+++ b/packages/coinlib-bitcoin/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib"
+    "outDir": "dist"
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/coinlib-common/package.json
+++ b/packages/coinlib-common/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "browser": "dist/index.umd.js",
-  "types": "dist/lib/index.d.ts",
-  "esnext": "dist/lib/index.js",
+  "types": "dist/index.d.ts",
+  "esnext": "dist/index.js",
   "repository": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib-common",
   "homepage": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib-common#readme",
   "bugs": {

--- a/packages/coinlib-common/tsconfig.build.json
+++ b/packages/coinlib-common/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.build.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib",
+    "outDir": "dist",
   },
   "include": ["src"]
 }

--- a/packages/coinlib-common/tsconfig.json
+++ b/packages/coinlib-common/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib"
+    "outDir": "dist"
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/coinlib-doge/package.json
+++ b/packages/coinlib-doge/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "browser": "dist/index.umd.js",
-  "types": "dist/lib/index.d.ts",
-  "esnext": "dist/lib/index.js",
+  "types": "dist/index.d.ts",
+  "esnext": "dist/index.js",
   "repository": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib-doge",
   "homepage": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib-doge#readme",
   "bugs": {

--- a/packages/coinlib-doge/tsconfig.build.json
+++ b/packages/coinlib-doge/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.build.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib",
+    "outDir": "dist",
   },
   "include": ["src"]
 }

--- a/packages/coinlib-doge/tsconfig.json
+++ b/packages/coinlib-doge/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib"
+    "outDir": "dist"
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/coinlib-ethereum/package.json
+++ b/packages/coinlib-ethereum/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "browser": "dist/index.umd.js",
-  "types": "dist/lib/index.d.ts",
-  "esnext": "dist/lib/index.js",
+  "types": "dist/index.d.ts",
+  "esnext": "dist/index.js",
   "repository": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib-ethereum",
   "homepage": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib-ethereum#readme",
   "bugs": {

--- a/packages/coinlib-ethereum/tsconfig.build.json
+++ b/packages/coinlib-ethereum/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.build.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib",
+    "outDir": "dist",
   },
   "include": ["src"]
 }

--- a/packages/coinlib-ethereum/tsconfig.json
+++ b/packages/coinlib-ethereum/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib"
+    "outDir": "dist"
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/coinlib-litecoin/package.json
+++ b/packages/coinlib-litecoin/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "browser": "dist/index.umd.js",
-  "types": "dist/lib/index.d.ts",
-  "esnext": "dist/lib/index.js",
+  "types": "dist/index.d.ts",
+  "esnext": "dist/index.js",
   "repository": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib-litecoin",
   "homepage": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib-litecoin#readme",
   "bugs": {

--- a/packages/coinlib-litecoin/tsconfig.build.json
+++ b/packages/coinlib-litecoin/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.build.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib",
+    "outDir": "dist",
   },
   "include": ["src"]
 }

--- a/packages/coinlib-litecoin/tsconfig.json
+++ b/packages/coinlib-litecoin/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib"
+    "outDir": "dist"
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/coinlib-ripple/package.json
+++ b/packages/coinlib-ripple/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "browser": "dist/index.umd.js",
-  "types": "dist/lib/index.d.ts",
-  "esnext": "dist/lib/index.js",
+  "types": "dist/index.d.ts",
+  "esnext": "dist/index.js",
   "repository": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib-ripple",
   "homepage": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib-ripple#readme",
   "bugs": {

--- a/packages/coinlib-ripple/tsconfig.build.json
+++ b/packages/coinlib-ripple/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.build.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib",
+    "outDir": "dist",
   },
   "include": ["src"]
 }

--- a/packages/coinlib-ripple/tsconfig.json
+++ b/packages/coinlib-ripple/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib"
+    "outDir": "dist"
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/coinlib-stellar/package.json
+++ b/packages/coinlib-stellar/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "browser": "dist/index.umd.js",
-  "types": "dist/lib/index.d.ts",
-  "esnext": "dist/lib/index.js",
+  "types": "dist/index.d.ts",
+  "esnext": "dist/index.js",
   "repository": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib-stellar",
   "homepage": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib-stellar#readme",
   "bugs": {

--- a/packages/coinlib-stellar/tsconfig.build.json
+++ b/packages/coinlib-stellar/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.build.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib",
+    "outDir": "dist",
   },
   "include": ["src"]
 }

--- a/packages/coinlib-stellar/tsconfig.json
+++ b/packages/coinlib-stellar/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib"
+    "outDir": "dist"
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/coinlib-tron/package.json
+++ b/packages/coinlib-tron/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "browser": "dist/index.umd.js",
-  "types": "dist/lib/index.d.ts",
-  "esnext": "dist/lib/index.js",
+  "types": "dist/index.d.ts",
+  "esnext": "dist/index.js",
   "repository": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib-tron",
   "homepage": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib-tron#readme",
   "bugs": {

--- a/packages/coinlib-tron/tsconfig.build.json
+++ b/packages/coinlib-tron/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.build.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib",
+    "outDir": "dist",
   },
   "include": ["src"]
 }

--- a/packages/coinlib-tron/tsconfig.json
+++ b/packages/coinlib-tron/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib"
+    "outDir": "dist"
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/coinlib/package.json
+++ b/packages/coinlib/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "browser": "dist/index.umd.js",
-  "types": "dist/lib/index.d.ts",
-  "esnext": "dist/lib/index.js",
+  "types": "dist/index.d.ts",
+  "esnext": "dist/index.js",
   "repository": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib",
   "homepage": "https://github.com/bitaccess/coinlib/tree/master/packages/coinlib#readme",
   "bugs": {

--- a/packages/coinlib/tsconfig.build.json
+++ b/packages/coinlib/tsconfig.build.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.build.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib",
+    "outDir": "dist",
   },
   "include": ["src"]
 }

--- a/packages/coinlib/tsconfig.json
+++ b/packages/coinlib/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist/lib",
+    "outDir": "dist",
     "typeRoots": [
       "./node_modules/@types",
       "../../node_modules/@types",


### PR DESCRIPTION
Signed-off-by: Denys Bitaccess <denys@bitaccess.co>

# Fix path in build script 


```
worker_1  | [nodemon] app crashed - waiting for file changes before starting...
app_1     | Error: Cannot find module '/app/packages/gringotts/node_modules/@bitaccess/coinlib/dist/index.cjs.js'. Please verify that the package.json has a valid "main" entry
app_1     |     at tryPackage (internal/modules/cjs/loader.js:321:19)
app_1     |     at Function.Module._findPath (internal/modules/cjs/loader.js:534:18)
app_1     |     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:888:27)
app_1     |     at Function.Module._resolveFilename (/app/packages/gringotts/node_modules/tsconfig-paths/src/register.ts:90:36)
app_1     |     at Function.Module._load (internal/modules/cjs/loader.js:746:27)
app_1     |     at Module.require (internal/modules/cjs/loader.js:974:19)
app_1     |     at require (internal/modules/cjs/helpers.js:101:18)
app_1     |     at Object.<anonymous> (/app/packages/gringotts/src/types/config.ts:4:1)
app_1     |     at Module._compile (internal/modules/cjs/loader.js:1085:14)
app_1     |     at Module.m._compile (/app/packages/gringotts/node_modules/ts-node/src/index.ts:858:23)
```