### PR TITLE
Add missing rollup step to build script

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -3,5 +3,15 @@
 # Builds the specified package. Designed to be run within that package dir.
 # Usage: build.sh <package_dir> [...args]
 
+NM_BIN="$1/node_modules/.bin"
+TSCONFIG="$1/tsconfig.build.json"
+ROLLUP_CONFIG="$1/rollup.config.js"
+
+echo ">> cd $1"
 cd "$1"
-tsc -p "$1/tsconfig.build.json"
+
+echo ">> tsc"
+"$NM_BIN/tsc" -b "$TSCONFIG"
+
+echo ">> rollup"
+"$NM_BIN/rollup" -c "$ROLLUP_CONFIG"

--- a/package.json
+++ b/package.json
@@ -1,20 +1,8 @@
 {
-  "name": "@bitaccess/coinlib",
-  "version": "0.17.2",
-  "description": "Unified interface for sending and receiving crypto payments",
-  "main": "packages/coin-payments/dist/index.cjs.js",
-  "module": "packages/coin-payments/dist/index.es.js",
-  "browser": "packages/coin-payments/dist/index.umd.js",
-  "types": "packages/coin-payments/dist/lib/index.d.ts",
-  "esnext": "packages/coin-payments/dist/lib/index.js",
-  "repository": "https://github.com/bitaccess/coin-payments/tree/master/packages/coin-payments",
-  "keywords": [
-    "coin",
-    "payments",
-    "crypto",
-    "faast",
-    "bitaccess"
-  ],
+  "name": "@bitaccess/coinlib-monorepo",
+  "version": "0.0.1",
+  "description": "Monorepo for coinlib: unified interface for sending and receiving crypto payments",
+  "repository": "https://github.com/bitaccess/coinlib",
   "author": "Dylan Seago <dylan@bitaccess.co>",
   "license": "MIT",
   "bugs": {
@@ -22,9 +10,6 @@
   },
   "engines": {
     "node": ">=12.0.0"
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "scripts": {
     "install:all": "lerna add",


### PR DESCRIPTION
When attempting to fix the broken builds, I eliminated the ts-config build script dependency and replaced it with just a tsc call. However this library also uses rollup so the build "succeeded", but was missing some artifacts because rollup never ran. That's why libraries depending on 6.0.3 cannot import the module, the .cjs.js files were missing.

Supersedes https://github.com/bitaccess/coinlib/pull/311

