### PR TITLE
[feat] (ethereum) Support custom network constants for L2/alt EVM chains

### DIFF
--- a/packages/coinlib-ethereum/src/HdEthereumPayments.ts
+++ b/packages/coinlib-ethereum/src/HdEthereumPayments.ts
@@ -1,3 +1,4 @@
+import { derivationPath } from './../../coinlib-ripple/src/bip44';
 import { BaseEthereumPayments } from './BaseEthereumPayments'
 import { HdEthereumPaymentsConfig, EthereumSignatory } from './types'
 import { deriveSignatory } from './bip44'
@@ -8,9 +9,11 @@ import { PUBLIC_CONFIG_OMIT_FIELDS } from './constants'
 export class HdEthereumPayments extends BaseEthereumPayments<HdEthereumPaymentsConfig> {
   readonly xprv: string | null
   readonly xpub: string
+  readonly derivationPath: string
 
   constructor(config: HdEthereumPaymentsConfig) {
     super(config)
+    this.derivationPath = config.derivationPath ?? this.networkConstants.defaultDerivationPath
     try {
       this.xprv = ''
       this.xpub = ''
@@ -18,7 +21,7 @@ export class HdEthereumPayments extends BaseEthereumPayments<HdEthereumPaymentsC
         this.xpub = config.hdKey
       } else if (this.isValidXprv(config.hdKey)) {
         this.xprv = config.hdKey
-        this.xpub = deriveSignatory(config.hdKey, 0).xkeys.xpub
+        this.xpub = deriveSignatory(config.hdKey, 0, this.derivationPath).xkeys.xpub
       } else {
         throw new Error(config.hdKey)
       }
@@ -27,8 +30,8 @@ export class HdEthereumPayments extends BaseEthereumPayments<HdEthereumPaymentsC
     }
   }
 
-  static generateNewKeys(): EthereumSignatory {
-    return deriveSignatory()
+  static generateNewKeys(derivationPath?: string): EthereumSignatory {
+    return deriveSignatory(undefined, undefined, derivationPath)
   }
 
   getXpub(): string {
@@ -40,6 +43,7 @@ export class HdEthereumPayments extends BaseEthereumPayments<HdEthereumPaymentsC
       ...omit(this.getFullConfig(), PUBLIC_CONFIG_OMIT_FIELDS),
       depositKeyIndex: this.depositKeyIndex,
       hdKey: this.getXpub(),
+      derivationPath: this.derivationPath,
     }
   }
 
@@ -52,7 +56,7 @@ export class HdEthereumPayments extends BaseEthereumPayments<HdEthereumPaymentsC
   }
 
   async getPayport(index: number): Promise<Payport> {
-    const { address } = deriveSignatory(this.getXpub(), index)
+    const { address } = deriveSignatory(this.getXpub(), index, this.derivationPath)
     if (!this.isValidAddress(address)) {
       // This should never happen
       throw new Error(`Cannot get address ${index} - validation failed for derived address`)
@@ -65,7 +69,7 @@ export class HdEthereumPayments extends BaseEthereumPayments<HdEthereumPaymentsC
       throw new Error(`Cannot get private key ${index} - HdEthereumPayments was created with an xpub`)
     }
 
-    return deriveSignatory(deriveSignatory(this.xprv, 0).xkeys.xprv, index).keys.prv
+    return deriveSignatory(deriveSignatory(this.xprv, 0, this.derivationPath).xkeys.xprv, index, this.derivationPath).keys.prv
   }
 }
 

--- a/packages/coinlib-ethereum/src/HdEthereumPayments.ts
+++ b/packages/coinlib-ethereum/src/HdEthereumPayments.ts
@@ -1,4 +1,3 @@
-import { derivationPath } from './../../coinlib-ripple/src/bip44';
 import { BaseEthereumPayments } from './BaseEthereumPayments'
 import { HdEthereumPaymentsConfig, EthereumSignatory } from './types'
 import { deriveSignatory } from './bip44'

--- a/packages/coinlib-ethereum/src/NetworkData.ts
+++ b/packages/coinlib-ethereum/src/NetworkData.ts
@@ -20,8 +20,8 @@ export class NetworkData {
   private gasStationUrl: string | undefined
   private parityUrl: string | undefined
   private logger: Logger
-  private blockBookService: NetworkDataBlockbook
-  private web3Service: NetworkDataWeb3
+  blockBookService: NetworkDataBlockbook
+  web3Service: NetworkDataWeb3
 
   constructor(config: NetworkDataConfig) {
     this.gasStationUrl = config.gasStationUrl ?? GAS_STATION_URL
@@ -31,7 +31,6 @@ export class NetworkData {
       ...config.blockBookConfig,
       server: config.blockBookConfig.nodes,
       logger: this.logger,
-      decimals: config.web3Config.decimals,
     })
 
     this.web3Service = new NetworkDataWeb3({

--- a/packages/coinlib-ethereum/src/UnitConvertersUtil.ts
+++ b/packages/coinlib-ethereum/src/UnitConvertersUtil.ts
@@ -1,34 +1,31 @@
 import { createUnitConverters } from '@bitaccess/coinlib-common'
 import { UnitConverters } from './types'
 
-import { ETH_DECIMAL_PLACES } from './constants'
-
 export class UnitConvertersUtil {
   toMainDenominationBigNumber: UnitConverters['toMainDenominationBigNumber']
   toBaseDenominationBigNumber: UnitConverters['toMainDenominationBigNumber']
   toMainDenomination: UnitConverters['toMainDenominationString']
   toBaseDenomination: UnitConverters['toBaseDenominationString']
 
-  toMainDenominationBigNumberEth: UnitConverters['toMainDenominationBigNumber']
-  toBaseDenominationBigNumberEth: UnitConverters['toMainDenominationBigNumber']
-  toMainDenominationEth: UnitConverters['toMainDenominationString']
-  toBaseDenominationEth: UnitConverters['toBaseDenominationString']
-  coinDecimals: number
+  toMainDenominationBigNumberNative: UnitConverters['toMainDenominationBigNumber']
+  toBaseDenominationBigNumberNative: UnitConverters['toMainDenominationBigNumber']
+  toMainDenominationNative: UnitConverters['toMainDenominationString']
+  toBaseDenominationNative: UnitConverters['toBaseDenominationString']
 
-  constructor(config: { coinDecimals?: number }) {
-    this.coinDecimals = config.coinDecimals ?? ETH_DECIMAL_PLACES
+  constructor(config: { coinDecimals?: number, nativeDecimals: number }) {
+    const coinDecimals = config.coinDecimals ?? config.nativeDecimals
 
-    const unitConverters = createUnitConverters(this.coinDecimals)
+    const unitConverters = createUnitConverters(coinDecimals)
     this.toMainDenominationBigNumber = unitConverters.toMainDenominationBigNumber
     this.toBaseDenominationBigNumber = unitConverters.toBaseDenominationBigNumber
     this.toMainDenomination = unitConverters.toMainDenominationString
     this.toBaseDenomination = unitConverters.toBaseDenominationString
 
-    const ethUnitConverters = createUnitConverters(ETH_DECIMAL_PLACES)
-    this.toMainDenominationBigNumberEth = ethUnitConverters.toMainDenominationBigNumber
-    this.toBaseDenominationBigNumberEth = ethUnitConverters.toBaseDenominationBigNumber
-    this.toMainDenominationEth = ethUnitConverters.toMainDenominationString
-    this.toBaseDenominationEth = ethUnitConverters.toBaseDenominationString
+    const nativeUnitConverters = createUnitConverters(config.nativeDecimals)
+    this.toMainDenominationBigNumberNative = nativeUnitConverters.toMainDenominationBigNumber
+    this.toBaseDenominationBigNumberNative = nativeUnitConverters.toBaseDenominationBigNumber
+    this.toMainDenominationNative = nativeUnitConverters.toMainDenominationString
+    this.toBaseDenominationNative = nativeUnitConverters.toBaseDenominationString
   }
 
   getCustomUnitConverter(decimals: number) {

--- a/packages/coinlib-ethereum/src/bip44.ts
+++ b/packages/coinlib-ethereum/src/bip44.ts
@@ -1,4 +1,3 @@
-import { derivationPath } from './../../coinlib-ripple/src/bip44';
 import Web3 from 'web3'
 import { EthereumSignatory } from './types'
 import { pubToAddress } from 'ethereumjs-util'

--- a/packages/coinlib-ethereum/src/constants.ts
+++ b/packages/coinlib-ethereum/src/constants.ts
@@ -1,15 +1,11 @@
 import { FeeLevel } from '@bitaccess/coinlib-common'
-import { EthTxType, EthereumAddressFormat } from './types'
+import { EthTxType, EthereumAddressFormat, NetworkConstants, EthereumPaymentsConfigKeys } from './types'
 
 export const PACKAGE_NAME = 'ethereum-payments'
-export const ETH_SYMBOL = 'ETH'
-export const ETH_NAME = 'Ethereum'
-export const ETH_DECIMAL_PLACES = 18
 
-export const DEFAULT_FULL_NODE = process.env.ETH_FULL_NODE_URL
-export const DEFAULT_SOLIDITY_NODE = process.env.ETH_SOLIDITY_NODE_URL
-export const DEFAULT_EVENT_SERVER = process.env.ETH_EVENT_SERVER_URL
 export const DEFAULT_FEE_LEVEL = FeeLevel.Medium
+export const DEFAULT_DERIVATION_PATH = "m/44'/60'/0'/0"
+export const DEFAULT_DECIMALS = 18
 
 export const MIN_CONFIRMATIONS = 0
 export const DEFAULT_GAS_PRICE_IN_WEI = '50000000000'
@@ -61,7 +57,7 @@ export const TOKEN_METHODS_ABI = JSON.parse(
 
 export const DEPOSIT_KEY_INDEX = 0
 
-export const PUBLIC_CONFIG_OMIT_FIELDS = [
+export const PUBLIC_CONFIG_OMIT_FIELDS: EthereumPaymentsConfigKeys[] = [
   'logger',
   'fullNode',
   'parityNode',
@@ -72,6 +68,7 @@ export const PUBLIC_CONFIG_OMIT_FIELDS = [
   'web3',
   'blockbookNode',
   'blockbookApi',
+  'networkConstants',
 ]
 
 export const DEFAULT_ADDRESS_FORMAT = EthereumAddressFormat.Lowercase
@@ -86,10 +83,21 @@ export const FULL_ERC20_TOKEN_METHODS_ABI = JSON.parse(
 )
 
 export const BALANCE_ACTIVITY_EVENT = 'activity'
-export const DEFAULT_MAINNET_SERVER = process.env.ETHEREUM_SERVER_URL
-  ? process.env.ETHEREUM_SERVER_URL.split(',')
-  : ['https://eth1.trezor.io', 'https://eth2.trezor.io']
 
-export const DEFAULT_TESTNET_SERVER = process.env.ETHEREUM_TESTNET_SERVER_URL
-  ? process.env.ETHEREUM_TESTNET_SERVER_URL.split(',')
-  : ['']
+export const DEFAULT_MAINNET_CONSTANTS: NetworkConstants = {
+  networkName: 'ethereum mainnet',
+  nativeCoinName: 'ether',
+  nativeCoinSymbol: 'ETH',
+  nativeCoinDecimals: DEFAULT_DECIMALS,
+  defaultDerivationPath: DEFAULT_DERIVATION_PATH,
+  chainId: 1,
+}
+
+export const DEFAULT_TESTNET_CONSTANTS: NetworkConstants = {
+  networkName: 'ethereum ropsten',
+  nativeCoinName: 'ropsten ether',
+  nativeCoinSymbol: 'ropstenETH',
+  nativeCoinDecimals: DEFAULT_DECIMALS,
+  defaultDerivationPath: DEFAULT_DERIVATION_PATH,
+  chainId: 3,
+}

--- a/packages/coinlib-ethereum/src/erc20/BaseErc20Payments.ts
+++ b/packages/coinlib-ethereum/src/erc20/BaseErc20Payments.ts
@@ -78,7 +78,7 @@ export abstract class BaseErc20Payments <Config extends BaseErc20PaymentsConfig>
     if (feeBase.isGreaterThan(ethBalance)) {
       throw new PaymentsError(
         PaymentsErrorCode.TxInsufficientBalance,
-        `Insufficient ETH balance (${this.toMainDenominationEth(ethBalance)}) to pay transaction fee of ${feeOption.feeMain}`,
+        `Insufficient ${this.nativeCoinSymbol} balance (${this.toMainDenominationNative(ethBalance)}) to pay transaction fee of ${feeOption.feeMain}`,
       )
     }
 
@@ -162,8 +162,8 @@ export abstract class BaseErc20Payments <Config extends BaseErc20PaymentsConfig>
     if (feeBase.isGreaterThan(ethBalance)) {
       throw new PaymentsError(
         PaymentsErrorCode.TxInsufficientBalance,
-        `Insufficient ETH balance (${this.toMainDenominationEth(ethBalance)}) at owner address ${signerAddress} `
-        + `to sweep contract ${from} with fee of ${feeOption.feeMain} ETH`)
+        `Insufficient ${this.nativeCoinSymbol} balance (${this.toMainDenominationNative(ethBalance)}) at owner address ${signerAddress} `
+        + `to sweep contract ${from} with fee of ${feeOption.feeMain} ${this.nativeCoinSymbol}`)
     }
 
     const { confirmedBalance: tokenBalanceMain } = await this.getBalance({ address: fromAddress })

--- a/packages/coinlib-ethereum/src/erc20/utils.ts
+++ b/packages/coinlib-ethereum/src/erc20/utils.ts
@@ -5,7 +5,7 @@ import { TOKEN_PROXY_DATA } from '../constants'
 import Web3 from 'web3'
 const web3 = new Web3()
 
-export function deriveAddress(creatorAddress: string, salt: string, hashed: boolean = false): string {
+export function deriveCreate2Address(creatorAddress: string, salt: string, hashed: boolean = false): string {
   const address = creatorAddress.replace(/0x/, '').toLowerCase()
   const proxy = web3.utils.sha3(TOKEN_PROXY_DATA.replace(/<address to proxy>/g, address))!
     .replace(/0x/, '').toLowerCase()

--- a/packages/coinlib-ethereum/src/utils.ts
+++ b/packages/coinlib-ethereum/src/utils.ts
@@ -34,7 +34,7 @@ export function resolveServer(
   { server, requestTimeoutMs, api }: EthereumBlockbookConnectedConfig,
   logger: Logger,
 ): {
-  api: BlockbookEthereum
+  api: BlockbookEthereum | null
   server: string[] | null
 } {
   if (api) {
@@ -75,11 +75,7 @@ export function resolveServer(
 
   // null server arg -> offline mode
   return {
-    api: new BlockbookEthereum({
-      nodes: [''],
-      logger,
-      requestTimeoutMs,
-    }),
+    api: null,
     server: null,
   }
 }

--- a/packages/coinlib-ethereum/test/EthereumPaymentsFactory.test.ts
+++ b/packages/coinlib-ethereum/test/EthereumPaymentsFactory.test.ts
@@ -1,4 +1,3 @@
-import { execPath } from 'process'
 import Web3 from 'web3'
 import { TestLogger } from '../../../common/testUtils'
 import {
@@ -9,10 +8,13 @@ import {
   HdEthereumPaymentsConfig,
   KeyPairEthereumPaymentsConfig,
   deriveSignatory,
+  DEFAULT_MAINNET_CONSTANTS,
+  NetworkConstants,
+  EthereumPaymentsUtilsConfig,
+  HdErc20Payments,
 } from '../src'
 
 import { hdAccount } from './fixtures/accounts'
-import { EthereumPaymentsUtilsConfig } from '../src/types';
 
 const logger = new TestLogger('EthereumPaymentsFactory')
 
@@ -34,6 +36,22 @@ const UTILS_CONFIG: EthereumPaymentsUtilsConfig = {
   logger,
 }
 
+const TOKEN_CONFIG = {
+  tokenAddress: '0x1234',
+  name: 'BA_TEST_TOKEN',
+  symbol: 'BTT',
+  decimals: 7,
+}
+
+const CUSTOM_NETWORK: NetworkConstants = {
+  networkName: 'Brilliant Baboon Blockchain',
+  nativeCoinName: 'Brilliant Baboon Booty',
+  nativeCoinSymbol: 'BBB',
+  nativeCoinDecimals: 888,
+  defaultDerivationPath: "m/44'/888'/0'/0",
+  chainId: 888,
+}
+
 describe('EthereumPaymentsFactory', () => {
   const factory = new EthereumPaymentsFactory()
 
@@ -44,8 +62,82 @@ describe('EthereumPaymentsFactory', () => {
       expect(hdP).toBeInstanceOf(HdEthereumPayments)
       expect(hdP.getPublicConfig()).toStrictEqual({
         depositKeyIndex: 0,
-        hdKey: deriveSignatory(account0.xkeys.xpub, 0).xkeys.xpub
+        hdKey: deriveSignatory(account0.xkeys.xpub, 0).xkeys.xpub,
+        derivationPath: DEFAULT_MAINNET_CONSTANTS.defaultDerivationPath,
       })
+      expect(hdP.coinDecimals).toBe(DEFAULT_MAINNET_CONSTANTS.nativeCoinDecimals)
+      expect(hdP.coinName).toBe(DEFAULT_MAINNET_CONSTANTS.nativeCoinName)
+      expect(hdP.coinSymbol).toBe(DEFAULT_MAINNET_CONSTANTS.nativeCoinSymbol)
+      expect(hdP.nativeCoinDecimals).toBe(DEFAULT_MAINNET_CONSTANTS.nativeCoinDecimals)
+      expect(hdP.nativeCoinName).toBe(DEFAULT_MAINNET_CONSTANTS.nativeCoinName)
+      expect(hdP.nativeCoinSymbol).toBe(DEFAULT_MAINNET_CONSTANTS.nativeCoinSymbol)
+      expect(hdP.networkConstants).toEqual(DEFAULT_MAINNET_CONSTANTS)
+    })
+
+    it('should instantiate HdEthereumPayments for custom network', () => {
+      const hdP = factory.newPayments({
+        ...HD_CONFIG,
+        networkConstants: CUSTOM_NETWORK,
+      })
+
+      expect(hdP).toBeInstanceOf(HdEthereumPayments)
+      expect(hdP.getPublicConfig()).toStrictEqual({
+        depositKeyIndex: 0,
+        hdKey: deriveSignatory(account0.xkeys.xpub, 0).xkeys.xpub,
+        derivationPath: CUSTOM_NETWORK.defaultDerivationPath,
+      })
+      expect(hdP.coinDecimals).toBe(CUSTOM_NETWORK.nativeCoinDecimals)
+      expect(hdP.coinName).toBe(CUSTOM_NETWORK.nativeCoinName)
+      expect(hdP.coinSymbol).toBe(CUSTOM_NETWORK.nativeCoinSymbol)
+      expect(hdP.nativeCoinDecimals).toBe(CUSTOM_NETWORK.nativeCoinDecimals)
+      expect(hdP.nativeCoinName).toBe(CUSTOM_NETWORK.nativeCoinName)
+      expect(hdP.nativeCoinSymbol).toBe(CUSTOM_NETWORK.nativeCoinSymbol)
+      expect(hdP.networkConstants).toEqual(CUSTOM_NETWORK)
+    })
+
+    it('should instantiate HdErc20Payments', () => {
+      const hdP = factory.newPayments({
+        ...HD_CONFIG,
+        ...TOKEN_CONFIG,
+      })
+
+      expect(hdP).toBeInstanceOf(HdErc20Payments)
+      expect(hdP.getPublicConfig()).toStrictEqual({
+        depositKeyIndex: 0,
+        hdKey: deriveSignatory(account0.xkeys.xpub, 0).xkeys.xpub,
+        derivationPath: DEFAULT_MAINNET_CONSTANTS.defaultDerivationPath,
+        ...TOKEN_CONFIG,
+      })
+      expect(hdP.coinDecimals).toBe(TOKEN_CONFIG.decimals)
+      expect(hdP.coinName).toBe(TOKEN_CONFIG.name)
+      expect(hdP.coinSymbol).toBe(TOKEN_CONFIG.symbol)
+      expect(hdP.nativeCoinDecimals).toBe(DEFAULT_MAINNET_CONSTANTS.nativeCoinDecimals)
+      expect(hdP.nativeCoinName).toBe(DEFAULT_MAINNET_CONSTANTS.nativeCoinName)
+      expect(hdP.nativeCoinSymbol).toBe(DEFAULT_MAINNET_CONSTANTS.nativeCoinSymbol)
+      expect(hdP.networkConstants).toEqual(DEFAULT_MAINNET_CONSTANTS)
+    })
+
+    it('should instantiate HdErc20Payments for custom network', () => {
+      const hdP = factory.newPayments({
+        ...HD_CONFIG,
+        ...TOKEN_CONFIG,
+        networkConstants: CUSTOM_NETWORK,
+      })
+
+      expect(hdP).toBeInstanceOf(HdErc20Payments)
+      expect(hdP.getPublicConfig()).toStrictEqual({
+        depositKeyIndex: 0,
+        hdKey: deriveSignatory(account0.xkeys.xpub, 0).xkeys.xpub,
+        derivationPath: CUSTOM_NETWORK.defaultDerivationPath,
+        ...TOKEN_CONFIG,
+      })
+      expect(hdP.coinDecimals).toBe(TOKEN_CONFIG.decimals)
+      expect(hdP.coinName).toBe(TOKEN_CONFIG.name)
+      expect(hdP.coinSymbol).toBe(TOKEN_CONFIG.symbol)
+      expect(hdP.nativeCoinDecimals).toBe(CUSTOM_NETWORK.nativeCoinDecimals)
+      expect(hdP.nativeCoinName).toBe(CUSTOM_NETWORK.nativeCoinName)
+      expect(hdP.nativeCoinSymbol).toBe(CUSTOM_NETWORK.nativeCoinSymbol)
+      expect(hdP.networkConstants).toEqual(CUSTOM_NETWORK)
     })
 
     it('should instantiate KeyPairEthereumPayments', () => {

--- a/packages/coinlib-ethereum/test/HdEthereumPayments.test.ts
+++ b/packages/coinlib-ethereum/test/HdEthereumPayments.test.ts
@@ -748,6 +748,7 @@ describe('HdEthereumPayments', () => {
         expect(pubConf).toStrictEqual({
           depositKeyIndex: 0,
           network: NetworkType.Testnet,
+          derivationPath: "m/44'/60'/0'/0",
           hdKey: INSTANCE_KEYS.xkeys.xpub,
         })
       })

--- a/packages/coinlib-ethereum/test/NetworkData.test.ts
+++ b/packages/coinlib-ethereum/test/NetworkData.test.ts
@@ -1,7 +1,7 @@
-import { DEFAULT_TESTNET_SERVER } from '../src/constants'
 import { NetworkData } from '../src/NetworkData'
 import { NetworkDataConfig } from '../src/types'
 import {
+  BLOCKBOOK_STATUS_MOCK,
   getEstimateGasMocks,
   getGasPriceMocks,
   getGasStationResponse,
@@ -18,14 +18,15 @@ const logger = new TestLogger('ethereum-payments.NetworkData')
 let id = 1
 
 describe('NetworkData', () => {
-  const GAS_STATION_URL = 'https://gasstation.test.url'
-  const PARITY_URL = 'https://parity.test.url'
-  const INFURA_URL = 'https://infura.test.url'
-  const BLOCKBOOK_NODES = DEFAULT_TESTNET_SERVER
+  const GAS_STATION_URL = 'https://gasstation.test.local'
+  const PARITY_URL = 'https://parity.test.local'
+  const INFURA_URL = 'https://infura.test.local'
+  const BLOCKBOOK_NODE = 'https://blockbook.test.local'
 
   const nockG = nock(GAS_STATION_URL)
   const nockP = nock(PARITY_URL)
   const nockI = nock(INFURA_URL)
+  const nockB = nock(BLOCKBOOK_NODE)
 
   const web3 = new Web3(INFURA_URL)
 
@@ -35,7 +36,7 @@ describe('NetworkData', () => {
   const networkDataConfig: NetworkDataConfig = {
     web3Config: { web3 },
     parityUrl: PARITY_URL,
-    blockBookConfig: { nodes: BLOCKBOOK_NODES },
+    blockBookConfig: { nodes: [BLOCKBOOK_NODE] },
     logger,
     gasStationUrl: GAS_STATION_URL,
   }
@@ -141,8 +142,9 @@ describe('NetworkData', () => {
   })
 
   it('should get the latest block', async () => {
+    nockB.get('/api/v2').reply(200, BLOCKBOOK_STATUS_MOCK)
     const currentBlock = await networkData.getCurrentBlockNumber()
 
-    expect(currentBlock).toBeDefined()
+    expect(currentBlock).toBe(BLOCKBOOK_STATUS_MOCK.blockbook.bestHeight)
   })
 })

--- a/packages/coinlib-ethereum/test/erc20/end-to-end.test.ts
+++ b/packages/coinlib-ethereum/test/erc20/end-to-end.test.ts
@@ -9,8 +9,6 @@ import {
   HdErc20Payments,
   HdErc20PaymentsConfig,
   EthereumPaymentsFactory,
-  DEFAULT_TESTNET_SERVER,
-  EthereumStandardizedTransaction,
   EthereumTransactionInfo,
 } from '../../src'
 import { CONTRACT_JSON, CONTRACT_GAS, CONTRACT_BYTECODE } from './fixtures/abi'

--- a/packages/coinlib-ethereum/test/fixtures/mocks.ts
+++ b/packages/coinlib-ethereum/test/fixtures/mocks.ts
@@ -506,3 +506,31 @@ export const getTransactionApisMocks = ({
 
   return id
 }
+
+export const BLOCKBOOK_STATUS_MOCK = {
+  "blockbook": {
+    "coin": "Ethereum",
+    "host": "blockbook-host",
+    "version": "0.3.6",
+    "gitCommit": "2002bd2",
+    "buildTime": "2022-07-04T14:21:45+00:00",
+    "syncMode": true,
+    "initialSync": false,
+    "inSync": true,
+    "bestHeight": 15136912,
+    "lastBlockTime": "2022-07-13T22:22:15.828026078Z",
+    "inSyncMempool": true,
+    "lastMempoolTime": "2022-07-13T22:22:37.583643591Z",
+    "mempoolSize": 418174,
+    "decimals": 18,
+    "dbSize": 194533397963,
+    "about": "Blockbook - blockchain indexer"
+  },
+  "backend": {
+    "chain": "mainnet",
+    "blocks": 15136912,
+    "bestBlockHash": "0x6fff5cb18e42375abec0d7ab83540481699d5edaf4ca2048ae452b36c9584aca",
+    "difficulty": "11213687248219436",
+    "version": "Geth/v1.10.19-stable-23bee162/linux-amd64/go1.18.1"
+  }
+}


### PR DESCRIPTION
In order to support Ethereum layer 2's (ie optimism, arbitrum) and alternative EVM chains (ie BSC, RSK) we need to allow the coinlib-ethereum classes to be instantiated with custom network constants. In particular an alternative `chainId` and `derivationPath` is typically needed, in addition to allow customization of the name/symbol/decimals of the native coin.

This change adds a new optional `networkConstants` field to the config objects so that all the exact same classes and logic can be shared across all chains. Additionally, both `HdEthereumPayments` and `HdErc20Payments` now support a `derivationPath` config option to enable user-specified overriding of the derivation path.