### PR TITLE
Throw error when deriving hd key to shallow path

### DIFF
--- a/packages/coinlib-common/src/HdKeyUtils.ts
+++ b/packages/coinlib-common/src/HdKeyUtils.ts
@@ -66,13 +66,19 @@ export function hdKeyToHdNode(hdKey: string, network?: Bip32Network): HDNode {
  * This partially applies the derivation path starting at the already derived depth of the provided key.
  */
 export function deriveHDNode(hdKey: string | HDNode, derivationPath: string, network?: Bip32Network): HDNode {
-  const rootNode = typeof hdKey === 'string'
+  const baseNode = typeof hdKey === 'string'
     ? hdKeyToHdNode(hdKey, network)
     : hdKey
-  const parts = splitDerivationPath(derivationPath).slice(rootNode.depth)
-  let node = rootNode
-  if (parts.length > 0) {
-    node = rootNode.derivePath(parts.join('/'))
+  const fullPathParts = splitDerivationPath(derivationPath)
+  if (baseNode.depth > fullPathParts.length) {
+    throw new Error(
+      `Cannot deriveHDNode to path ${derivationPath} because hdKey depth (${baseNode.depth}) is already deeper`
+    )
+  }
+  const partialPathParts = fullPathParts.slice(baseNode.depth)
+  let node = baseNode
+  if (partialPathParts.length > 0) {
+    node = baseNode.derivePath(partialPathParts.join('/'))
   }
   return node
 }

--- a/packages/coinlib-common/test/HdKeyUtils.test.ts
+++ b/packages/coinlib-common/test/HdKeyUtils.test.ts
@@ -1,12 +1,31 @@
+import { deriveHDNode } from '@bitaccess/coinlib-common';
 import { splitDerivationPath } from '../src/HdKeyUtils'
 
-export const DERIVATION_PATH = "m/44'/1337'/1'"
 
 describe('HdKeyUtils', () => {
 
   describe('splitDerivationPath', () => {
     it('returns correct value', () => {
-      expect(splitDerivationPath(DERIVATION_PATH)).toEqual(["44'", "1337'", "1'"])
+      const derivationPath = "m/44'/1337'/1'"
+      expect(splitDerivationPath(derivationPath)).toEqual(["44'", "1337'", "1'"])
+    })
+  })
+  describe('deriveHDNode', () => {
+    it('does nothing if path depth matches xpub depth', () => {
+      const pathWithDepth5 = "m/44'/60'/0'/0/0"
+      const xpubWithDepth5 = 'xpub6G7izREAqiUx62vvYbecBHWZVg99BDx3YtPq37BGCHrWt1EzrDsxd6fZUyZo2SjyXybknctAU7uh13RPWFfabBnsGGwV5danYtWTxxynsXi'
+      expect(deriveHDNode(
+        xpubWithDepth5,
+        pathWithDepth5,
+      ).toBase58()).toBe(xpubWithDepth5)
+    })
+    it('throws error if deriving to path shallower than key depth', () => {
+      const pathWithDepth4 = "m/44'/60'/0'/0"
+      const xpubWithDepth5 = 'xpub6G7izREAqiUx62vvYbecBHWZVg99BDx3YtPq37BGCHrWt1EzrDsxd6fZUyZo2SjyXybknctAU7uh13RPWFfabBnsGGwV5danYtWTxxynsXi'
+      expect(() => deriveHDNode(
+        xpubWithDepth5,
+        pathWithDepth4,
+      )).toThrow(`Cannot deriveHDNode to path ${pathWithDepth4} because hdKey depth (5) is already deeper`)
     })
   })
 })


### PR DESCRIPTION
If an xpub with depth 5 is passed into the deriveHDNode function and a path is provided that itself is shorter than depth 5, throw an error because that's a sign that an incorrect derivation path was specified that doesn't actually match the xpub. The path should always have equal or more parts than the base key that's going to be derived.