### PR TITLE
[GG-265] fix coinlib ethereum type error

### DIFF
--- a/packages/coinlib-ethereum/src/EthereumBalanceMonitor.ts
+++ b/packages/coinlib-ethereum/src/EthereumBalanceMonitor.ts
@@ -46,13 +46,21 @@ export class EthereumBalanceMonitor extends EthereumPaymentsUtils implements Bal
     return rawTx
   }
 
+  private async getStandardizedTx(rawTx: NormalizedTxEthereum) {
+    const currentBlockNumber = await this.getCurrentBlockNumber()
+
+    return this.networkData.blockBookService.standardizeTransaction(rawTx, { currentBlockNumber })
+  }
+
   async subscribeAddresses(addresses: string[]): Promise<void> {
     const validAddresses = addresses.filter(address => this.standardizeAddressOrThrow(address))
 
     await this.networkData.subscribeAddresses(validAddresses, async (address, rawTx) => {
       this.events.emit('tx', { address, tx: rawTx })
 
-      const activity = await this.txToBalanceActivity(address, rawTx)
+      const standardizedTx = await this.getStandardizedTx(rawTx)
+
+      const activity = await this.txToBalanceActivity(address, standardizedTx)
 
       if (activity) {
         if (Array.isArray(activity)) {
@@ -127,7 +135,9 @@ export class EthereumBalanceMonitor extends EthereumPaymentsUtils implements Bal
           continue
         }
 
-        const balanceActivities = await this.txToBalanceActivity(address, tx)
+        const standardizedTx = await this.getStandardizedTx(tx)
+
+        const balanceActivities = await this.txToBalanceActivity(address, standardizedTx)
 
         await callbackFn(balanceActivities, tx)
       }
@@ -143,10 +153,7 @@ export class EthereumBalanceMonitor extends EthereumPaymentsUtils implements Bal
     tx: EthereumStandardizedTransaction,
     cache: { [txid: string]: NormalizedTxEthereum },
   ) {
-    const involvedAddresses = new Set(
-      [tx.from, tx.to]
-        .map((a) => this.standardizeAddressOrThrow(a))
-    )
+    const involvedAddresses = new Set([tx.from, tx.to].map(a => this.standardizeAddressOrThrow(a)))
 
     const rawTx = await this.getTxWithMemoization(tx.txHash, cache)
 
@@ -196,7 +203,9 @@ export class EthereumBalanceMonitor extends EthereumPaymentsUtils implements Bal
       for (const { txHash } of relevantAddressTransactions) {
         const rawTx = await this.getTxWithMemoization(txHash, hardTxQueries)
 
-        const balanceActivities = await this.txToBalanceActivity(relevantAddress, rawTx)
+        const standardizedTx = await this.getStandardizedTx(rawTx)
+
+        const balanceActivities = await this.txToBalanceActivity(relevantAddress, standardizedTx)
 
         await callbackFn(balanceActivities, rawTx)
       }
@@ -249,23 +258,22 @@ export class EthereumBalanceMonitor extends EthereumPaymentsUtils implements Bal
 
   private getBalanceActivityForNonTokenTransfer(
     address: string,
-    tx: NormalizedTxEthereum,
+    tx: EthereumStandardizedTransaction,
     fee: BigNumber,
   ): BalanceActivity[] {
-    const { fromAddress, toAddress } = getBlockBookTxFromAndToAddress(tx)
-
-    const timestamp = new Date(tx.blockTime * 1000)
+    const fromAddress = tx.from
+    const toAddress = tx.to
 
     const baseBalanceActivity: BalanceActivity = {
       networkType: this.networkType,
       networkSymbol: this.coinSymbol,
       assetSymbol: this.coinSymbol,
       address: this.standardizeAddressOrThrow(address),
-      externalId: tx.txid,
-      activitySequence: String(tx.ethereumSpecific.nonce),
+      externalId: tx.txHash,
+      activitySequence: String(tx.nonce),
       confirmationId: tx.blockHash ?? '',
       confirmationNumber: tx.blockHeight,
-      timestamp,
+      timestamp: tx.blockTime!,
       amount: this.toMainDenomination(tx.value),
       extraId: null,
       confirmations: tx.confirmations,
@@ -278,7 +286,11 @@ export class EthereumBalanceMonitor extends EthereumPaymentsUtils implements Bal
       return this.getSelfBalanceActivities(baseBalanceActivity, fee)
     }
 
-    const type = this.getActivityType(address, { txFromAddress: fromAddress, txToAddress: toAddress, txHash: tx.txid })
+    const type = this.getActivityType(address, {
+      txFromAddress: fromAddress,
+      txToAddress: toAddress,
+      txHash: tx.txHash,
+    })
 
     const balanceActivities: BalanceActivity[] = []
 
@@ -306,22 +318,22 @@ export class EthereumBalanceMonitor extends EthereumPaymentsUtils implements Bal
     return balanceActivities
   }
 
-  async txToBalanceActivity(address: string, tx: NormalizedTxEthereum): Promise<BalanceActivity[]> {
+  async txToBalanceActivity(address: string, tx: EthereumStandardizedTransaction): Promise<BalanceActivity[]> {
     if (tx.blockHeight <= 0) {
       // NOTE not yet confirmed on blockbook
       return []
     }
 
-    const fee = new BigNumber(tx.ethereumSpecific.gasPrice).multipliedBy(tx.ethereumSpecific.gasUsed)
+    const fee = new BigNumber(tx.gasPrice).multipliedBy(tx.gasUsed)
 
     if (!tx.tokenTransfers || tx.tokenTransfers.length === 0) {
       return this.getBalanceActivityForNonTokenTransfer(address, tx, fee)
     }
 
-    const nonce = String(tx.ethereumSpecific.nonce)
-    const txHash = tx.txid
+    const nonce = String(tx.nonce)
+    const txHash = tx.txHash
 
-    const timestamp = new Date(tx.blockTime * 1000)
+    const timestamp = tx.blockTime!
 
     const balanceActivities: BalanceActivity[] = tx.tokenTransfers
       .filter(tokenTransfer => {
@@ -364,8 +376,7 @@ export class EthereumBalanceMonitor extends EthereumPaymentsUtils implements Bal
         return balanceActivity
       })
 
-    const { fromAddress } = getBlockBookTxFromAndToAddress(tx)
-    const isTxSender = this.isAddressEqual(fromAddress, address)
+    const isTxSender = this.isAddressEqual(tx.from, address)
 
     if (isTxSender) {
       // add the balance activity for the fee
@@ -374,8 +385,8 @@ export class EthereumBalanceMonitor extends EthereumPaymentsUtils implements Bal
         networkSymbol: this.coinSymbol,
         assetSymbol: this.coinSymbol,
         address: this.standardizeAddressOrThrow(address),
-        externalId: tx.txid,
-        activitySequence: String(tx.ethereumSpecific.nonce),
+        externalId: tx.txHash,
+        activitySequence: String(tx.nonce),
         confirmationId: tx.blockHash ?? '',
         confirmationNumber: tx.blockHeight,
         timestamp,

--- a/packages/coinlib-ethereum/src/NetworkDataBlockbook.ts
+++ b/packages/coinlib-ethereum/src/NetworkDataBlockbook.ts
@@ -63,14 +63,16 @@ export class NetworkDataBlockbook implements EthereumNetworkDataProvider {
 
     const transactionHashes: string[] = []
     const standardizedTransactions: EthereumStandardizedTransaction[] = []
-    for (const tx of (block.txs ?? [])) {
+    for (const tx of block.txs ?? []) {
       transactionHashes.push(tx.txid)
 
       if (includeTransactionObjects) {
-        standardizedTransactions.push(this.standardizeTransaction(tx, {
-          blockInfoTime,
-          currentBlockNumber,
-        }))
+        standardizedTransactions.push(
+          this.standardizeTransaction(tx, {
+            blockInfoTime,
+            currentBlockNumber,
+          }),
+        )
       }
     }
 
@@ -162,15 +164,18 @@ export class NetworkDataBlockbook implements EthereumNetworkDataProvider {
     return token.balance!
   }
 
-  standardizeTransaction(tx: NormalizedTxEthereum, {
-    currentBlockNumber,
-    blockInfoTime,
-    txSpecific,
-  }: {
-    currentBlockNumber: number,
-    txSpecific?: SpecificTxEthereum,
-    blockInfoTime?: Date
-  }): EthereumStandardizedTransaction {
+  standardizeTransaction(
+    tx: NormalizedTxEthereum,
+    {
+      currentBlockNumber,
+      blockInfoTime,
+      txSpecific,
+    }: {
+      currentBlockNumber: number
+      txSpecific?: SpecificTxEthereum
+      blockInfoTime?: Date
+    },
+  ): EthereumStandardizedTransaction {
     const { fromAddress, toAddress, contractAddress } = getBlockBookTxFromAndToAddress(tx)
 
     const blockTime = blockInfoTime ? new Date(blockInfoTime) : new Date(tx.blockTime * 1000)
@@ -196,6 +201,7 @@ export class NetworkDataBlockbook implements EthereumNetworkDataProvider {
         ...tx,
         ...txSpecific?.tx,
       },
+      tokenTransfers: tx.tokenTransfers ?? [],
     }
 
     return standardizedTransaction
@@ -214,7 +220,7 @@ export class NetworkDataBlockbook implements EthereumNetworkDataProvider {
     tokenSymbol: string
     tokenDecimals: string
     tokenName: string
-    currentBlockNumber: number,
+    currentBlockNumber: number
   }): EthereumStandardizedERC20Transaction {
     const standardizedTx = this.standardizeTransaction(tx, { txSpecific, currentBlockNumber })
 

--- a/packages/coinlib-ethereum/src/types.ts
+++ b/packages/coinlib-ethereum/src/types.ts
@@ -221,19 +221,29 @@ export const KeyPairErc20PaymentsConfig = extendCodec(
 )
 export type KeyPairErc20PaymentsConfig = t.TypeOf<typeof KeyPairErc20PaymentsConfig>
 
-export const Erc20PaymentsConfig = t.union([HdErc20PaymentsConfig, UHdErc20PaymentsConfig, KeyPairErc20PaymentsConfig], 'Erc20PaymentsConfig')
+export const Erc20PaymentsConfig = t.union(
+  [HdErc20PaymentsConfig, UHdErc20PaymentsConfig, KeyPairErc20PaymentsConfig],
+  'Erc20PaymentsConfig',
+)
 export type Erc20PaymentsConfig = t.TypeOf<typeof Erc20PaymentsConfig>
 
 export const EthereumPaymentsConfig = t.union(
-  [HdEthereumPaymentsConfig, UHdEthereumPaymentsConfig, KeyPairEthereumPaymentsConfig, HdErc20PaymentsConfig, UHdErc20PaymentsConfig, KeyPairErc20PaymentsConfig],
+  [
+    HdEthereumPaymentsConfig,
+    UHdEthereumPaymentsConfig,
+    KeyPairEthereumPaymentsConfig,
+    HdErc20PaymentsConfig,
+    UHdErc20PaymentsConfig,
+    KeyPairErc20PaymentsConfig,
+  ],
   'EthereumPaymentsConfig',
 )
 export type EthereumPaymentsConfig = t.TypeOf<typeof EthereumPaymentsConfig>
 
 export type EthereumPaymentsConfigKeys =
-| keyof HdEthereumPaymentsConfig
-| keyof UHdEthereumPaymentsConfig
-| keyof KeyPairEthereumPaymentsConfig
+  | keyof HdEthereumPaymentsConfig
+  | keyof UHdEthereumPaymentsConfig
+  | keyof KeyPairEthereumPaymentsConfig
   | keyof HdErc20PaymentsConfig
   | keyof UHdErc20PaymentsConfig
   | keyof KeyPairErc20PaymentsConfig
@@ -430,6 +440,17 @@ export interface EthereumStandardizedReceipt {
   logs: any[]
 }
 
+export interface ERC20TokenTransfer {
+  type: 'ERC20' | string
+  from: string
+  to: string
+  token: string
+  name: string
+  symbol: string
+  decimals: number
+  value: string
+}
+
 export interface EthereumStandardizedTransaction {
   from: string
   to: string
@@ -448,6 +469,7 @@ export interface EthereumStandardizedTransaction {
   currentBlockNumber: number
   dataProvider: NetworkDataProviders
   receipt?: EthereumStandardizedReceipt
+  tokenTransfers: ERC20TokenTransfer[]
 }
 
 export interface EthereumStandardizedERC20Transaction extends EthereumStandardizedTransaction {


### PR DESCRIPTION
- Improve `EthereumStandardizedTransaction` to include token transfers.
- Change `EthereumBalanceMonitor.txToBalanceActivity` to accept a `EthereumStandardizedTransaction`  type as opposed to the `NormalizedTxEthereum` returned by blockbook.
