### PR TITLE
Fix/network min relay fee

### DIFF
--- a/packages/coinlib-bitcoin-cash/src/constants.ts
+++ b/packages/coinlib-bitcoin-cash/src/constants.ts
@@ -19,9 +19,9 @@ export const DEFAULT_DUST_THRESHOLD = 546
 /**
  * The minimum fee required by *most* nodes to relay a transaction.
  *
- * Unit: `sat/byte`
+ * Unit: `sat/kbyte`
  */
-export const DEFAULT_NETWORK_MIN_RELAY_FEE = 1 // 1000 sat/kb
+export const DEFAULT_NETWORK_MIN_RELAY_FEE = 1000 // 1000 sat/kb
 
 /** Sequence to use for each input such that RBF is opted into */
 export const BITCOIN_SEQUENCE_RBF = 0xfffffffd

--- a/packages/coinlib-bitcoin/src/bitcoinish/BitcoinishPayments.ts
+++ b/packages/coinlib-bitcoin/src/bitcoinish/BitcoinishPayments.ts
@@ -269,7 +269,7 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
     // add one sat extra to avoid inaccurate size estimate resulting in insufficient relay fee
     const minRelaySat = 1 + this.feeRateToSatoshis(
       {
-        feeRate: String(this.networkMinRelayFee),
+        feeRate: String(this.networkMinRelayFee / 1000),
         feeRateType: FeeRateType.BasePerWeight
       },
       inputCount,

--- a/packages/coinlib-bitcoin/src/bitcoinish/BitcoinishPaymentsUtils.ts
+++ b/packages/coinlib-bitcoin/src/bitcoinish/BitcoinishPaymentsUtils.ts
@@ -37,7 +37,7 @@ export abstract class BitcoinishPaymentsUtils extends BlockbookConnected impleme
   readonly coinName: string
   readonly coinDecimals: number
   readonly bitcoinjsNetwork: BitcoinjsNetwork
-  readonly networkMinRelayFee: number // sat/vb
+  readonly networkMinRelayFee: number // sat/kb
   readonly dustThreshold: number // sats
   readonly blockcypherToken?: string
   feeLevelBlockTargets: FeeLevelBlockTargets
@@ -198,7 +198,7 @@ export abstract class BitcoinishPaymentsUtils extends BlockbookConnected impleme
   }
 
   isAddressBalanceSweepable(balance: Numeric): boolean {
-    return this.toBaseDenominationNumber(balance) >= this.dustThreshold + this.networkMinRelayFee * MIN_P2PKH_SWEEP_BYTES
+    return this.toBaseDenominationNumber(balance) >= this.dustThreshold + this.networkMinRelayFee * MIN_P2PKH_SWEEP_BYTES / 1000
   }
 
   async getAddressBalance(address: string): Promise<BalanceResult> {

--- a/packages/coinlib-bitcoin/src/bitcoinish/types.ts
+++ b/packages/coinlib-bitcoin/src/bitcoinish/types.ts
@@ -100,7 +100,7 @@ export const BitcoinishPaymentsUtilsConfig = extendCodec(
     coinName: t.string,
     coinDecimals: t.number,
     bitcoinjsNetwork: BitcoinjsNetwork,
-    networkMinRelayFee: t.number, // sat/vb
+    networkMinRelayFee: t.number, // sat/kbytes
     dustThreshold: t.number, // sat
   },
   {

--- a/packages/coinlib-bitcoin/src/constants.ts
+++ b/packages/coinlib-bitcoin/src/constants.ts
@@ -20,9 +20,9 @@ export const DEFAULT_DUST_THRESHOLD = 546
  *
  * See: https://github.com/bitcoin/bitcoin/blob/master/src/policy/policy.h#L57
  *
- * Unit: `sat/vb`
+ * Unit: `sat/kbytes`
  */
-export const DEFAULT_NETWORK_MIN_RELAY_FEE_RATE = 1 // 1000 sat/kb
+export const DEFAULT_NETWORK_MIN_RELAY_FEE_RATE = 1000 // 1000 sat/kb
 
 /** Sequence to use for each input such that RBF is opted into */
 export const BITCOIN_SEQUENCE_RBF = 0xfffffffd

--- a/packages/coinlib-doge/src/constants.ts
+++ b/packages/coinlib-doge/src/constants.ts
@@ -22,9 +22,9 @@ export const DEFAULT_DUST_THRESHOLD = 1e6 // 0.01 DOGE
  *
  * See https://github.com/dogecoin/dogecoin/blob/v1.14.6/src/validation.h#L57
  *
- * Unit: `sat/byte`
+ * Unit: `sat/kbyte`
  */
-export const DEFAULT_NETWORK_MIN_RELAY_FEE = 1e2 // 0.001 DOGE per kb
+export const DEFAULT_NETWORK_MIN_RELAY_FEE = 1e5 // 0.001 DOGE per kb
 
 /** Sequence to use for each input such that RBF is opted into */
 export const BITCOIN_SEQUENCE_RBF = 0xfffffffd

--- a/packages/coinlib-litecoin/src/constants.ts
+++ b/packages/coinlib-litecoin/src/constants.ts
@@ -18,9 +18,9 @@ export const DEFAULT_DUST_THRESHOLD = 546
 /**
  * The minimum fee required by *most* nodes to relay a transaction.
  *
- * Unit: `sat/vb`
+ * Unit: `sat/kb`
  */
-export const DEFAULT_NETWORK_MIN_RELAY_FEE = 1 // 1000 sat/kb
+export const DEFAULT_NETWORK_MIN_RELAY_FEE = 1000 // 1000 sat/kb
 
 /** Sequence to use for each input such that RBF is opted into */
 export const LITECOIN_SEQUENCE_RBF = 0xfffffffd

--- a/packages/coinlib-litecoin/test/e2e.mainnet.test.ts
+++ b/packages/coinlib-litecoin/test/e2e.mainnet.test.ts
@@ -177,7 +177,7 @@ describeAll('e2e mainnet', () => {
       it('succeeds for low level', async () => {
         const estimate = await payments.getFeeRateRecommendation(FeeLevel.Low, { source: 'blockbook' })
         expect(estimate.feeRateType).toBe(FeeRateType.BasePerWeight)
-        expect(Number.parseFloat(estimate.feeRate)).toBeGreaterThanOrEqual(1)
+        expect(Number.parseFloat(estimate.feeRate)).toBeGreaterThan(0)
       })
     })
   })

--- a/packages/coinlib-litecoin/test/e2e.testnet.multisig.test.ts
+++ b/packages/coinlib-litecoin/test/e2e.testnet.multisig.test.ts
@@ -195,7 +195,11 @@ describeAll('e2e multisig testnet', () => {
             maxFeePercent: 100,
           })
           expect(tx.multisigData).toBeDefined()
-          expect(new BigNumber(tx.amount).plus(tx.fee).toFixed()).toBe(fromBalance.toString())
+          const EPSILON: number = 0.001
+          const balanceLeft: number = fromBalance.minus(tx.amount).minus(tx.fee).toNumber()
+          expect(balanceLeft).toBeGreaterThanOrEqual(0)
+          expect(balanceLeft).toBeLessThan(EPSILON)
+
         },
         30 * 1000,
       )


### PR DESCRIPTION
# Description of the change

1. fix 2 coinlib-litecoin tests

2. Gringotts is using the unit sat/Kbytes for networkMinRelayFee, but coinlib was using sat/bytes
this pr changes coinlib to use sat/bytes
