### PR TITLE
add getSpecificPayments to CoinPayments

### DIFF
--- a/packages/coinlib-litecoin/test/e2e.mainnet.test.ts
+++ b/packages/coinlib-litecoin/test/e2e.mainnet.test.ts
@@ -171,7 +171,7 @@ describeAll('e2e mainnet', () => {
       it('succeeds for high level', async () => {
         const estimate = await payments.getFeeRateRecommendation(FeeLevel.High, { source: 'blockbook' })
         expect(estimate.feeRateType).toBe(FeeRateType.BasePerWeight)
-        expect(Number.parseFloat(estimate.feeRate)).toBeGreaterThanOrEqual(1)
+        expect(Number.parseFloat(estimate.feeRate)).toBeGreaterThan(0)
       })
 
       it('succeeds for low level', async () => {

--- a/packages/coinlib/src/CoinPayments.ts
+++ b/packages/coinlib/src/CoinPayments.ts
@@ -49,15 +49,17 @@ export class CoinPayments {
         (config.seed.includes(' ') ? bip39.mnemonicToSeedSync(config.seed) : Buffer.from(config.seed, 'hex'))) ||
       undefined
     const accountIdSet = new Set<string>()
-    SUPPORTED_NETWORK_SYMBOLS.forEach(networkSymbol => {
-      const networkConfig = config[networkSymbol]
-      if (!networkConfig && !this.seedBuffer) {
-        return
-      }
-      const networkPayments = this.newPayments(networkSymbol, networkConfig)
-      this.payments[networkSymbol] = networkPayments
-      networkPayments.getAccountIds().forEach(id => accountIdSet.add(id))
-    })
+    if (!config.emptyPayment) {
+      SUPPORTED_NETWORK_SYMBOLS.forEach(networkSymbol => {
+        const networkConfig = config[networkSymbol]
+        if (!networkConfig && !this.seedBuffer) {
+          return
+        }
+        const networkPayments = this.newPayments(networkSymbol, networkConfig)
+        this.payments[networkSymbol] = networkPayments
+        networkPayments.getAccountIds().forEach(id => accountIdSet.add(id))
+      })
+    }
     this.accountIds = Array.from(accountIdSet)
   }
 

--- a/packages/coinlib/src/CoinPayments.ts
+++ b/packages/coinlib/src/CoinPayments.ts
@@ -49,7 +49,7 @@ export class CoinPayments {
         (config.seed.includes(' ') ? bip39.mnemonicToSeedSync(config.seed) : Buffer.from(config.seed, 'hex'))) ||
       undefined
     const accountIdSet = new Set<string>()
-    if (!config.emptyPayment) {
+    if (!config.skipInitialInstantiation) {
       SUPPORTED_NETWORK_SYMBOLS.forEach(networkSymbol => {
         const networkConfig = config[networkSymbol]
         if (!networkConfig && !this.seedBuffer) {

--- a/packages/coinlib/src/CoinPayments.ts
+++ b/packages/coinlib/src/CoinPayments.ts
@@ -126,6 +126,13 @@ export class CoinPayments {
     return payments
   }
 
+  getSpecificPayments<T extends SupportedCoinPaymentsSymbol>(
+    networkSymbol: T,
+    networkConfig: CoinPaymentsPartialConfigs[T],
+  ): AnyPayments {
+    return this.newPayments(networkSymbol, networkConfig)
+  }
+
   isNetworkSupported(networkSymbol: string): networkSymbol is SupportedCoinPaymentsSymbol {
     return SupportedCoinPaymentsSymbol.is(networkSymbol)
   }

--- a/packages/coinlib/src/types.ts
+++ b/packages/coinlib/src/types.ts
@@ -7,18 +7,22 @@ import { StellarPaymentsConfig, BaseStellarPaymentsConfig, StellarPaymentsUtils 
 import { BitcoinPaymentsConfig, BaseBitcoinPaymentsConfig, BitcoinPaymentsUtils } from '@bitaccess/coinlib-bitcoin'
 import { EthereumPaymentsConfig, BaseEthereumPaymentsConfig, EthereumPaymentsUtils } from '@bitaccess/coinlib-ethereum'
 import { LitecoinPaymentsConfig, BaseLitecoinPaymentsConfig, LitecoinPaymentsUtils } from '@bitaccess/coinlib-litecoin'
-import { BitcoinCashPaymentsConfig, BaseBitcoinCashPaymentsConfig, BitcoinCashPaymentsUtils } from '@bitaccess/coinlib-bitcoin-cash'
+import {
+  BitcoinCashPaymentsConfig,
+  BaseBitcoinCashPaymentsConfig,
+  BitcoinCashPaymentsUtils,
+} from '@bitaccess/coinlib-bitcoin-cash'
 import { DogePaymentsConfig, BaseDogePaymentsConfig, DogePaymentsUtils } from '@bitaccess/coinlib-doge'
 
 export type CoinPaymentsUtilsClasses = {
-  TRX: TronPaymentsUtils,
-  XRP: RipplePaymentsUtils,
-  XLM: StellarPaymentsUtils,
-  BTC: BitcoinPaymentsUtils,
-  ETH: EthereumPaymentsUtils,
-  LTC: LitecoinPaymentsUtils,
-  BCH: BitcoinCashPaymentsUtils,
-  DOGE: DogePaymentsUtils,
+  TRX: TronPaymentsUtils
+  XRP: RipplePaymentsUtils
+  XLM: StellarPaymentsUtils
+  BTC: BitcoinPaymentsUtils
+  ETH: EthereumPaymentsUtils
+  LTC: LitecoinPaymentsUtils
+  BCH: BitcoinCashPaymentsUtils
+  DOGE: DogePaymentsUtils
 }
 
 export const basePaymentsConfigCodecs = {
@@ -29,7 +33,7 @@ export const basePaymentsConfigCodecs = {
   ETH: BaseEthereumPaymentsConfig,
   LTC: BaseLitecoinPaymentsConfig,
   BCH: BaseBitcoinCashPaymentsConfig,
-  DOGE: BaseDogePaymentsConfig
+  DOGE: BaseDogePaymentsConfig,
 }
 
 export const CoinPaymentsBaseConfigs = t.type(basePaymentsConfigCodecs, 'CoinPaymentsBaseConfigs')
@@ -54,10 +58,9 @@ export type SupportedCoinPaymentsSymbol = t.TypeOf<typeof SupportedCoinPaymentsS
 export type CoinPaymentsPartialConfigs = {
   [T in SupportedCoinPaymentsSymbol]?: Partial<CoinPaymentsConfigs[T]>
 }
-export const CoinPaymentsPartialConfigs = t.partial(
-  basePaymentsConfigCodecs,
-  'CoinPaymentsPartialConfigs',
-) as t.Type<CoinPaymentsPartialConfigs>
+export const CoinPaymentsPartialConfigs = t.partial(basePaymentsConfigCodecs, 'CoinPaymentsPartialConfigs') as t.Type<
+  CoinPaymentsPartialConfigs
+>
 
 export const CoinPaymentsConfig = extendCodec(
   CoinPaymentsPartialConfigs,
@@ -66,6 +69,7 @@ export const CoinPaymentsConfig = extendCodec(
     network: NetworkTypeT,
     logger: Logger,
     seed: t.string,
+    emptyPayment: t.boolean,
   },
   'CoinPaymentsConfig',
 )

--- a/packages/coinlib/src/types.ts
+++ b/packages/coinlib/src/types.ts
@@ -69,7 +69,7 @@ export const CoinPaymentsConfig = extendCodec(
     network: NetworkTypeT,
     logger: Logger,
     seed: t.string,
-    emptyPayment: t.boolean,
+    skipInitialInstantiation: t.boolean,
   },
   'CoinPaymentsConfig',
 )

--- a/packages/coinlib/test/CoinPayments.test.ts
+++ b/packages/coinlib/test/CoinPayments.test.ts
@@ -117,8 +117,8 @@ describe('CoinPayments', () => {
     })
     describe('getPublicConfig with skipInitialInstantiation client should return emtpy object', () => {
       it('returns correctly', () => {
-        const skipInitialInstantiation = new CoinPayments({ ...CONFIG, skipInitialInstantiation: true })
-        expect(skipInitialInstantiation.getPublicConfig()).toEqual({})
+        const emptyPayment = new CoinPayments({ ...CONFIG, skipInitialInstantiation: true })
+        expect(emptyPayment.getPublicConfig()).toEqual({})
       })
     })
 

--- a/packages/coinlib/test/CoinPayments.test.ts
+++ b/packages/coinlib/test/CoinPayments.test.ts
@@ -71,6 +71,15 @@ describe('CoinPayments', () => {
       })
     })
 
+    describe('getSpecificPayments', () => {
+      it('returns for configured', () => {
+        expect(cp.getSpecificPayments(CONFIGURED_ASSET, CONFIG[CONFIGURED_ASSET])).toBeInstanceOf(EXPECTED_PAYMENTS_TYPE)
+      })
+      it('throws for unsupported', () => {
+        expect(() => cp.forNetwork(UNSUPPORTED_ASSET, CONFIG[CONFIGURED_ASSET])).toThrow()
+      })
+    })
+
     describe('isNetworkConfigured', () => {
       it('returns true for configured', () => {
         expect(cp.isNetworkConfigured(CONFIGURED_ASSET)).toBe(true)

--- a/packages/coinlib/test/CoinPayments.test.ts
+++ b/packages/coinlib/test/CoinPayments.test.ts
@@ -115,6 +115,13 @@ describe('CoinPayments', () => {
         expect(cp.getPublicConfig()).toEqual(omit(CONFIG, [UNCONFIGURED_ASSET]))
       })
     })
+    describe('getPublicConfig with emptyPayment client should return emtpy object', () => {
+      it('returns correctly', () => {
+        const emptyPayment = new CoinPayments({ ...CONFIG, emptyPayment: true })
+        expect(emptyPayment.getPublicConfig()).toEqual({})
+      })
+    })
+
   })
 
   describe('instance seed', () => {

--- a/packages/coinlib/test/CoinPayments.test.ts
+++ b/packages/coinlib/test/CoinPayments.test.ts
@@ -115,10 +115,10 @@ describe('CoinPayments', () => {
         expect(cp.getPublicConfig()).toEqual(omit(CONFIG, [UNCONFIGURED_ASSET]))
       })
     })
-    describe('getPublicConfig with emptyPayment client should return emtpy object', () => {
+    describe('getPublicConfig with skipInitialInstantiation client should return emtpy object', () => {
       it('returns correctly', () => {
-        const emptyPayment = new CoinPayments({ ...CONFIG, emptyPayment: true })
-        expect(emptyPayment.getPublicConfig()).toEqual({})
+        const skipInitialInstantiation = new CoinPayments({ ...CONFIG, skipInitialInstantiation: true })
+        expect(skipInitialInstantiation.getPublicConfig()).toEqual({})
       })
     })
 


### PR DESCRIPTION
# Problem

The old way to get `AnyPayments` instance is to build it in `CoinPayments` constructor and store them in the `CoinPayments` object and later use `forNetwork` method to get the pre-defined payments config combined with the overriding config and build another one. The first build in the CoinPayments constructor is unnecessary for our `GringottsSeedSignerClient`. 


# Description of the change

This pr adds a method `getSpecificPayments` to allow users to get any payment instance directly from an 'empty' CoinPayments(aka seedCoinPayments) without pre-building anyPayments in `CoinPayments` constructor.