### PR TITLE
[GG-336] pass down [includeTransactionObjects] argument

### DIFF
--- a/packages/coinlib-ethereum/src/NetworkData.ts
+++ b/packages/coinlib-ethereum/src/NetworkData.ts
@@ -67,7 +67,7 @@ export class NetworkData {
   }
 
   async getBlock(blockId: string | number, includeTransactionObjects: boolean = false): Promise<BlockInfo> {
-    return this.callBlockbookWithWeb3Fallback('getBlock', blockId)
+    return this.callBlockbookWithWeb3Fallback('getBlock', blockId, includeTransactionObjects)
   }
 
   async getAddressDetails(address: string, options?: GetAddressDetailsOptions) {


### PR DESCRIPTION
# Description of the change

 The `includeTransactionObjects` argument was not being passed to the functions that resolves the blockbook/web3 calls. This caused  the api to return block data without transactions objects which in turn affects the balance monitor for ETH, causing it not to find the address involved in  transactions inside the block. 